### PR TITLE
libgit2: add a dependency on openssl

### DIFF
--- a/recipes-deps/libgit2/libgit2.inc
+++ b/recipes-deps/libgit2/libgit2.inc
@@ -2,7 +2,7 @@ SUMMARY = "the Git linkable library"
 HOMEPAGE = "http://libgit2.github.com/"
 LICENSE = "GPL-2.0-with-linking-exception"
 
-DEPENDS = "zlib"
+DEPENDS = "openssl zlib"
 
 inherit cmake
 


### PR DESCRIPTION
If this dependency is missing its possible that openssl won't be built
before libgit2 is built and then we won't have git support over SSL
which leaves out a lot of git repos. Should fix the issue mentioned in #53.