### PR TITLE
Update Cargo, bbclass cleanup

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -42,18 +42,6 @@ cargo_do_configure () {
 	echo "]" >>../.cargo/config
 }
 
-rust_cargo_patch () {
-	# FIXME: if there is already an entry for this target, in an existing
-	# cargo/config, this won't work.
-	cd "${S}"
-	cat >>Cargo.toml <<EOF
-[profile.dev]
-rpath = true
-[profile.release]
-rpath = true
-EOF
-}
-
 # All the rust & cargo ecosystem assume that CC, LD, etc are a path to a single
 # command. Fixup the ones we give it so that is the case.
 # XXX: this is hard coded based on meta/conf/bitbake.conf
@@ -70,6 +58,7 @@ export CARGO_BUILD_FLAGS = "-v --target ${HOST_SYS} --release"
 # change if CARGO_BUILD_FLAGS changes.
 export CARGO_TARGET_SUBDIR="${HOST_SYS}/release"
 oe_cargo_build () {
+	export RUSTFLAGS="${RUSTFLAGS}"
 	which cargo
 	which rustc
 	bbnote ${CARGO} build ${CARGO_BUILD_FLAGS} "$@"

--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -11,10 +11,6 @@ def cargo_base_dep(d):
 
 BASEDEPENDS_append = " ${@cargo_base_dep(d)}"
 
-# FIXME: this is a workaround for a misbehavior in cargo when used with quilt.
-# See https://github.com/rust-lang/cargo/issues/978
-PATCHTOOL = "patch"
-
 # Cargo only supports in-tree builds at the moment
 B = "${S}"
 

--- a/classes/rust-bin.bbclass
+++ b/classes/rust-bin.bbclass
@@ -1,14 +1,7 @@
 inherit rust
 
-RUSTLIB_DEP ?= " rustlib"
-DEPENDS .= "${RUSTLIB_DEP}"
-RDEPENDS_${PN} .= "${RUSTLIB_DEP}"
+RDEPENDS_${PN} += "${RUSTLIB_DEP}"
 DEPENDS += "patchelf-native"
-
-export rustlibdir = "${libdir}/rust"
-FILES_${PN} += "${rustlibdir}/*.so"
-FILES_${PN}-dev += "${rustlibdir}/*.rlib"
-FILES_${PN}-dbg += "${rustlibdir}/.debug"
 
 RUSTC_ARCHFLAGS += "-C opt-level=3 -g -L ${STAGING_DIR_HOST}/${rustlibdir}"
 EXTRA_OEMAKE += 'RUSTC_ARCHFLAGS="${RUSTC_ARCHFLAGS}"'
@@ -37,11 +30,6 @@ OVERLAP_DEPS = "${@get_overlap_deps(d)}"
 RUSTC_PREFER_DYNAMIC = "-C prefer-dynamic"
 RUSTC_FLAGS += "${RUSTC_PREFER_DYNAMIC}"
 
-rustlib_suffix="${TUNE_ARCH}${TARGET_VENDOR}-${TARGET_OS}/rustlib/${HOST_SYS}/lib"
-# Native sysroot standard library path
-rustlib_src="${prefix}/lib/${rustlib_suffix}"
-# Host sysroot standard library path
-rustlib="${libdir}/${rustlib_suffix}"
 CRATE_NAME ?= "${@d.getVar('BPN', True).replace('-rs', '').replace('-', '_')}"
 BINNAME ?= "${BPN}"
 LIBNAME ?= "lib${CRATE_NAME}-rs"

--- a/classes/rust-bin.bbclass
+++ b/classes/rust-bin.bbclass
@@ -1,7 +1,6 @@
 inherit rust
 
 RDEPENDS_${PN} += "${RUSTLIB_DEP}"
-DEPENDS += "patchelf-native"
 
 RUSTC_ARCHFLAGS += "-C opt-level=3 -g -L ${STAGING_DIR_HOST}/${rustlibdir}"
 EXTRA_OEMAKE += 'RUSTC_ARCHFLAGS="${RUSTC_ARCHFLAGS}"'
@@ -89,19 +88,3 @@ oe_install_rust_bin () {
     echo Installing ${BINNAME}
     install -D -m 755 ${BINNAME} ${D}/${bindir}/${BINNAME}
 }
-
-do_rust_bin_fixups() {
-    for f in `find ${PKGD} -name '*.so*'`; do
-        echo "Strip rust note: $f"
-        ${OBJCOPY} -R .note.rustc $f $f
-    done
-
-    for f in `find ${PKGD}`; do
-        file "$f" | grep -q ELF || continue
-        readelf -d "$f" | grep RUNPATH | grep -q rustlib || continue
-        echo "Set rpath:" "$f"
-        patchelf --set-rpath '$ORIGIN:'${rustlibdir}:${rustlib} "$f"
-    done
-}
-
-PACKAGE_PREPROCESS_FUNCS += "do_rust_bin_fixups"

--- a/classes/rust.bbclass
+++ b/classes/rust.bbclass
@@ -15,7 +15,7 @@ def rust_base_dep(d):
             deps += " rust-native"
     return deps
 
-DEPENDS_append = " ${@rust_base_dep(d)}"
+DEPENDS_append = " ${@rust_base_dep(d)} patchelf-native"
 
 def rust_base_triple(d, thing):
     '''
@@ -85,6 +85,21 @@ HOST_CXXFLAGS ?= "${CXXFLAGS}"
 HOST_CPPFLAGS ?= "${CPPFLAGS}"
 
 EXTRA_OECONF_remove = "--disable-static"
+
+do_rust_bin_fixups() {
+    for f in `find ${PKGD} -name '*.so*'`; do
+        echo "Strip rust note: $f"
+        ${OBJCOPY} -R .note.rustc $f $f
+    done
+
+    for f in `find ${PKGD}`; do
+        file "$f" | grep -q ELF || continue
+        readelf -d "$f" | grep RUNPATH | grep -q rustlib || continue
+        echo "Set rpath:" "$f"
+        patchelf --set-rpath '$ORIGIN:'${rustlibdir}:${rustlib} "$f"
+    done
+}
+PACKAGE_PREPROCESS_FUNCS += "do_rust_bin_fixups"
 
 rustlib_suffix="${TUNE_ARCH}${TARGET_VENDOR}-${TARGET_OS}/rustlib/${HOST_SYS}/lib"
 # Native sysroot standard library path

--- a/classes/rust.bbclass
+++ b/classes/rust.bbclass
@@ -3,13 +3,14 @@ RUSTC = "rustc"
 # FIXME: --sysroot might be needed
 RUSTC_ARCHFLAGS += "--target=${TARGET_SYS} -C rpath -C crate_hash=${BB_TASKHASH}"
 
+RUSTLIB_DEP ?= "rustlib"
 def rust_base_dep(d):
     # Taken from meta/classes/base.bbclass `base_dep_prepend` and modified to
     # use rust instead of gcc
     deps = ""
     if not d.getVar('INHIBIT_DEFAULT_RUST_DEPS', True):
         if (d.getVar('HOST_SYS', True) != d.getVar('BUILD_SYS', True)):
-            deps += " virtual/${TARGET_PREFIX}rust"
+            deps += " virtual/${TARGET_PREFIX}rust ${RUSTLIB_DEP}"
         else:
             deps += " rust-native"
     return deps
@@ -84,3 +85,13 @@ HOST_CXXFLAGS ?= "${CXXFLAGS}"
 HOST_CPPFLAGS ?= "${CPPFLAGS}"
 
 EXTRA_OECONF_remove = "--disable-static"
+
+rustlib_suffix="${TUNE_ARCH}${TARGET_VENDOR}-${TARGET_OS}/rustlib/${HOST_SYS}/lib"
+# Native sysroot standard library path
+rustlib_src="${prefix}/lib/${rustlib_suffix}"
+# Host sysroot standard library path
+rustlib="${libdir}/${rustlib_suffix}"
+export rustlibdir = "${libdir}/rust"
+FILES_${PN} += "${rustlibdir}/*.so"
+FILES_${PN}-dev += "${rustlibdir}/*.rlib"
+FILES_${PN}-dbg += "${rustlibdir}/.debug"

--- a/classes/rust.bbclass
+++ b/classes/rust.bbclass
@@ -1,7 +1,8 @@
 RUSTC = "rustc"
 
 # FIXME: --sysroot might be needed
-RUSTC_ARCHFLAGS += "--target=${TARGET_SYS} -C rpath -C crate_hash=${BB_TASKHASH}"
+RUSTFLAGS += "-C rpath -C crate_hash=${BB_TASKHASH}"
+RUSTC_ARCHFLAGS += "--target=${TARGET_SYS} ${RUSTFLAGS}"
 
 RUSTLIB_DEP ?= "rustlib"
 def rust_base_dep(d):

--- a/recipes-devtools/cargo/cargo_0.10.0.bb
+++ b/recipes-devtools/cargo/cargo_0.10.0.bb
@@ -38,8 +38,8 @@ SRC_URI += "\
 	file://ssh2-rs/0001-libssh2-sys-avoid-explicitly-linking-in-openssl.patch;patchdir=../ssh2-rs \
 "
 
-# 0.2.10 / -sys 0.1.34
-SRCREV_ssh2-rs = "00af6ead0c3d4b82e05bee4d9963ef3823bcf524"
+# 0.2.11 / -sys 0.1.37
+SRCREV_ssh2-rs = "ced77751cb780d0725a3411bd588c5a26ea79953"
 
 SRCREV_FORMAT .= "_ssh2-rs"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/ssh2-rs"

--- a/recipes-devtools/cargo/cargo_0.10.0.bb
+++ b/recipes-devtools/cargo/cargo_0.10.0.bb
@@ -6,8 +6,8 @@ SRC_URI += " \
 	file://0001-disable-cargo-snapshot-fetch.patch \
 	git://github.com/rust-lang/rust-installer.git;protocol=https;name=rust-installer;destsuffix=${BP}/src/rust-installer \
 "
-SRC_URI[cargo.md5sum] = "c3002e297f125ad40b2e0279219163bc"
-SRC_URI[cargo.sha256sum] = "4cadc436be442505851f3a8e9ffff1ef10b6379101a7f8e0afa9fa80f5198f89"
+SRC_URI[cargo.md5sum] = "98ab2a422634d447152380898a974b08"
+SRC_URI[cargo.sha256sum] = "1e73c038681fe308195427b71322a6350c65d3b8cbea199e45c7b672b4754e0e"
 
 SRCREV_rust-installer = "c37d3747da75c280237dc2d6b925078e69555499"
 

--- a/recipes-devtools/cargo/files/0001-disable-cargo-snapshot-fetch.patch
+++ b/recipes-devtools/cargo/files/0001-disable-cargo-snapshot-fetch.patch
@@ -1,4 +1,4 @@
-From 9652ddba460f30e83f401ab1564656e7787bdea9 Mon Sep 17 00:00:00 2001
+From 7ae8ea6523c943cc819eadea011ce4f783e40764 Mon Sep 17 00:00:00 2001
 From: Cody P Schafer <dev@codyps.com>
 Date: Wed, 3 Feb 2016 15:59:48 -0500
 Subject: [PATCH] disable cargo snapshot fetch
@@ -8,20 +8,20 @@ Subject: [PATCH] disable cargo snapshot fetch
  1 file changed, 4 deletions(-)
 
 diff --git a/Makefile.in b/Makefile.in
-index 286a593..9c66486 100644
+index fadcb4b..a8da630 100644
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -92,10 +92,6 @@ test-unit-$(1): $$(CARGO)
+@@ -103,10 +103,6 @@ test-unit-$(1): $$(CARGO)
  endef
  $(foreach target,$(CFG_TARGET),$(eval $(call CARGO_TARGET,$(target))))
  
--$(TARGET_ROOT)/snapshot/bin/cargo$(X): src/snapshots.txt
--	$(CFG_PYTHON) src/etc/dl-snapshot.py $(CFG_BUILD)
+-$(TARGET_ROOT)/snapshot/bin/cargo$(X): $(S)src/snapshots.txt
+-	$(CFG_PYTHON) $(S)src/etc/dl-snapshot.py $(CFG_BUILD)
 -	touch $@
 -
  
  # === Tests
  
 -- 
-2.7.0
+2.8.2
 

--- a/recipes-devtools/cargo/files/ssh2-rs/0001-libssh2-sys-avoid-explicitly-linking-in-openssl.patch
+++ b/recipes-devtools/cargo/files/ssh2-rs/0001-libssh2-sys-avoid-explicitly-linking-in-openssl.patch
@@ -1,20 +1,20 @@
-From be07c11b438550829d82dc844e38806570232cd7 Mon Sep 17 00:00:00 2001
+From 65f07216c2c7a341cf13c35ecc1a781d7a489511 Mon Sep 17 00:00:00 2001
 From: Cody P Schafer <dev@codyps.com>
 Date: Sat, 12 Dec 2015 22:44:14 -0500
 Subject: [PATCH] libssh2-sys: avoid explicitly linking in openssl
 
 ---
- libssh2-sys/Cargo.toml | 25 -------------------------
+ libssh2-sys/Cargo.toml | 33 ---------------------------------
  libssh2-sys/lib.rs     |  2 --
- 2 files changed, 27 deletions(-)
+ 2 files changed, 35 deletions(-)
 
 diff --git a/libssh2-sys/Cargo.toml b/libssh2-sys/Cargo.toml
-index b9ecec2..78f92ac 100644
+index c4e006d..175be77 100644
 --- a/libssh2-sys/Cargo.toml
 +++ b/libssh2-sys/Cargo.toml
-@@ -18,31 +18,6 @@ libc = "0.2"
- ws2_32-sys = ">= 0"
- winapi = "0.2"
+@@ -19,39 +19,6 @@ libc = "0.2"
+ [target."cfg(unix)".dependencies]
+ openssl-sys = ">= 0"
  
 -[target.i686-apple-darwin.dependencies]
 -openssl-sys = ">= 0"
@@ -22,13 +22,21 @@ index b9ecec2..78f92ac 100644
 -openssl-sys = ">= 0"
 -[target.i686-unknown-linux-gnu.dependencies]
 -openssl-sys = ">= 0"
+-[target.i586-unknown-linux-gnu.dependencies]
+-openssl-sys = ">= 0"
 -[target.x86_64-unknown-linux-gnu.dependencies]
 -openssl-sys = ">= 0"
 -[target.aarch64-unknown-linux-gnu.dependencies]
 -openssl-sys = ">= 0"
+-[target.powerpc64-unknown-linux-gnu.dependencies]
+-openssl-sys = ">= 0"
+-[target.powerpc64le-unknown-linux-gnu.dependencies]
+-openssl-sys = ">= 0"
 -[target.x86_64-unknown-linux-musl.dependencies]
 -openssl-sys = ">= 0"
 -[target.arm-unknown-linux-gnueabihf.dependencies]
+-openssl-sys = ">= 0"
+-[target.armv7-unknown-linux-gnueabihf.dependencies]
 -openssl-sys = ">= 0"
 -[target.i686-unknown-freebsd.dependencies]
 -openssl-sys = ">= 0"
@@ -45,11 +53,11 @@ index b9ecec2..78f92ac 100644
  pkg-config = "0.3"
  cmake = "0.1.2"
 diff --git a/libssh2-sys/lib.rs b/libssh2-sys/lib.rs
-index bb6c46f..40af82f 100644
+index 02fd203..3ca1806 100644
 --- a/libssh2-sys/lib.rs
 +++ b/libssh2-sys/lib.rs
-@@ -6,8 +6,6 @@ extern crate ws2_32;
- extern crate winapi;
+@@ -4,8 +4,6 @@
+ extern crate libc;
  
  extern crate libz_sys;
 -#[cfg(unix)]
@@ -58,5 +66,5 @@ index bb6c46f..40af82f 100644
  use libc::{c_int, size_t, c_void, c_char, c_long, c_uchar, c_uint, c_ulong};
  use libc::ssize_t;
 -- 
-2.4.10
+2.8.2
 


### PR DESCRIPTION
Move some variables from `rust-bin.bbclass` to `rust.bbclass`, working toward commonality between rust-bin and cargo.

The new version of cargo allows a couple `cargo.bbclass` hacks to be removed.

I tested that dynamically-linked rust-bin apps execute on the generated target image and rust-hello-world (cargo) builds.