### PR TITLE
rustc: fix use of shared source for new poky/oe-core which wipes ${S}

### DIFF
--- a/classes/shared-source-use.bbclass
+++ b/classes/shared-source-use.bbclass
@@ -1,3 +1,23 @@
+# gcc's shared source code disables fetch (via the commented code below). We
+# can't do that because rust.bb currently fetches a rustc-snapshot archive itself.
+#do_fetch() {
+#	:
+#}
+#do_fetch[noexec] = "1"
+
+# gcc does `deltask` do_unpack. We avoid this so that the depends work sanely
+# (things that need source code can still be ordered after do_unpack).
+# As a side effect, we can also unpack things that aren't shared.
+# Note: just setting this normally doesn't work. Use of python() is required.
+python () {
+	d.setVarFlag('do_unpack', 'cleandirs', '')
+}
+# Avoid disabling do_patch for the same reason.
+#deltask do_patch
+
+SRC_URI = ""
+
 S = "${TMPDIR}/work-shared/${SOURCE_NAME}-${PV}-${PR}"
 
 do_unpack[depends] += "${SOURCE_NAME}-source-${PV}:do_patch"
+do_populate_lic[depends] += "${SOURCE_NAME}-source-${PV}:do_unpack"


### PR DESCRIPTION
The oe-core/poky change 'base.bbclass wipe ${S} before unpacking
source' (poky: a56fb90dc3805494eeaf04c60538425e8d52efc5, oe-core:
eccae514b71394ffaed8fc45dea7942152a334a1) wipes ${S} in do_unpack prior
to unpacking. This breaks our shared source as we set ${S} to the shared
location, and don't actually unpack anything (the result is we try to
build rustc without any source code, which fails predictably)

Avoid this by copying a bit more of gcc-shared-source.inc to disable
do_unpack for shared source users.

This is a bit of a hack, and only barely works (due to our need for
rust-snapshot). In the future, it might make sense to have the
rust-snapshot be shared in some fashion as well (which would allow us to disable fetch and more closely mimic gcc-shared-source.inc).