### PR TITLE
rust: add a backport fix to use /dev/urandom in cases where the random m pool isn't yet initialized

### DIFF
--- a/recipes-devtools/rust/files/rust/fix-urandom-during-init.patch
+++ b/recipes-devtools/rust/files/rust/fix-urandom-during-init.patch
@@ -1,0 +1,42 @@
+rust: don't block before random pool is initialized
+
+Upstream-Status: Backport [See https://github.com/rust-lang/rust/pull/33086]
+
+Signed-off-by: Derek Straka <derek@asterius.io>
+--- ./src/libstd/rand/os.rs.orig	2016-08-18 13:14:25.908309986 -0400
++++ ./src/libstd/rand/os.rs	2016-08-18 13:14:11.316560875 -0400
+@@ -46,8 +46,10 @@
+         #[cfg(target_arch = "aarch64")]
+         const NR_GETRANDOM: libc::c_long = 278;
+ 
++        const GRND_NONBLOCK: libc::c_uint = 0x0001;
++
+         unsafe {
+-            libc::syscall(NR_GETRANDOM, buf.as_mut_ptr(), buf.len(), 0)
++            libc::syscall(NR_GETRANDOM, buf.as_mut_ptr(), buf.len(), GRND_NONBLOCK)
+         }
+     }
+ 
+@@ -69,7 +71,20 @@
+                 let err = errno() as libc::c_int;
+                 if err == libc::EINTR {
+                     continue;
+-                } else {
++                } else if err == libc::EAGAIN {
++                    // if getrandom() returns EAGAIN it would have blocked
++                    // because the non-blocking pool (urandom) has not
++                    // initialized in the kernel yet due to a lack of entropy
++                    // the fallback we do here is to avoid blocking applications
++                    // which could depend on this call without ever knowing
++                    // they do and don't have a work around. The PRNG of
++                    // /dev/urandom will still be used but not over a completely
++                    // full entropy pool
++                    let reader = File::open("/dev/urandom").expect("Unable to open /dev/urandom");
++                    let mut reader_rng = ReaderRng::new(reader);
++                    reader_rng.fill_bytes(& mut v[read..]);
++                    read += v.len() as usize;
++                else {
+                     panic!("unexpected getrandom error: {}", err);
+                 }
+             } else {
+

--- a/recipes-devtools/rust/rust-source.bb
+++ b/recipes-devtools/rust/rust-source.bb
@@ -27,4 +27,5 @@ SRC_URI_append = "\
         file://rust-llvm/0000-rust-llvm-remove-extra-slash.patch \
         file://rust-installer/0001-add-option-to-disable-rewriting-of-install-paths.patch;patchdir=src/rust-installer \
         file://rust/0001-Add-config-for-musl-based-arm-builds.patch \
+        file://rust/fix-urandom-during-init.patch \
 "


### PR DESCRIPTION
Signed-off-by: Derek Straka <derek@asterius.io>