### PR TITLE
compiler-rt: ensure -e is passed to make

### DIFF
--- a/recipes-devtools/rust/compiler-rt.bb
+++ b/recipes-devtools/rust/compiler-rt.bb
@@ -9,6 +9,9 @@ LIC_FILES_CHKSUM = "file://LICENSE.TXT;md5=27b14ab4ce08d04c3a9a5f0ed7997362"
 S .= "/src/compiler-rt"
 B = "${WORKDIR}/build"
 
+# Pick up $CC from the environment
+EXTRA_OEMAKE += "-e"
+
 do_compile () {
 	oe_runmake -C ${S} \
 		ProjSrcRoot="${S}" \


### PR DESCRIPTION
OE-Core rev aeb653861a0ec39ea7a014c0622980edcbf653fa (between jethro and
krogoth) removed -e from the default flags in EXTRA_OEMAKE. Without
this, the makefile will default to gcc for CC.