### PR TITLE
rust-cross: fix build where TARGET_ARCH and HOST_ARCH are the same

### DIFF
--- a/recipes-devtools/rust/rust-cross.bb
+++ b/recipes-devtools/rust/rust-cross.bb
@@ -40,7 +40,7 @@ do_compile () {
 
 do_install () {
 	mkdir -p ${D}${prefix}/${base_libdir_native}/rustlib
-	cp ${WORKDIR}/targets/${TARGET_ARCH}* ${D}${prefix}/${base_libdir_native}/rustlib
+	cp ${WORKDIR}/targets/${TARGET_SYS}.json ${D}${prefix}/${base_libdir_native}/rustlib
 }
 
 rust_cross_sysroot_preprocess() {


### PR DESCRIPTION
By copying exactly the target we intend to.

Fixes #77 

Testing with new enough poky may also need #78 