### PR TITLE
libgit2: add missing dependencies

### DIFF
--- a/recipes-deps/libgit2/libgit2.inc
+++ b/recipes-deps/libgit2/libgit2.inc
@@ -2,7 +2,7 @@ SUMMARY = "the Git linkable library"
 HOMEPAGE = "http://libgit2.github.com/"
 LICENSE = "GPL-2.0-with-GCC-exception"
 
-DEPENDS = "openssl zlib"
+DEPENDS = "curl openssl zlib libssh2"
 
 inherit cmake
 


### PR DESCRIPTION
Without these dependencies cargo is unable to fetch packages from SSH
based repos. This same fix is already upstream in meta-oe master at:
http://cgit.openembedded.org/meta-openembedded/tree/meta-oe/recipes-support/libgit2/libgit2_0.24.1.bb