### PR TITLE
Small cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+build/
+poky/

--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -35,7 +35,7 @@
 #MACHINE ?= "edgerouter"
 #
 # This sets the default machine to be qemux86 if no other machine is selected:
-MACHINE ??= "qemux86"
+MACHINE ??= "qemux86-64"
 
 #
 # Where to place downloads

--- a/recipes-devtools/rust/rust-llvm.inc
+++ b/recipes-devtools/rust/rust-llvm.inc
@@ -33,11 +33,11 @@ do_install_append () {
 	# Remove the debug info (>2 GB) as part of normal operation
 	rm -rf ${D}${bindir}/.debug
 
-	cd ${D}${bindir}
-	ln -s *-llc llc
-	for i in *-llvm-*; do
-		link=$(echo $i | sed -e 's/.*-llvm-\(.*\)/\1/')
-		ln -sf $i llvm-$link
+	cd ${D}${bindir} || bbfatal "failed to cd ${D}${bindir}"
+	for i in *-llvm-* *-llc *-lli *-FileCheck; do
+		link=$(echo $i | sed -e "s/${TARGET_SYS}-\(.*\)/\1/")
+		[ -e "${i}" ] || bbfatal "no such file to symlink to ${i}"
+		ln -sf "$i" "${link}" || bbfatal "failed to symlink ${link} to ${i}"
 	done
 }
 

--- a/recipes-devtools/rust/rust-llvm_1.10.0.bb
+++ b/recipes-devtools/rust/rust-llvm_1.10.0.bb
@@ -2,9 +2,3 @@ require rust-llvm.inc
 
 SRC_URI[rust.md5sum] = "a48fef30353fc9daa70b484b690ce5db"
 SRC_URI[rust.sha256sum] = "a4015aacf4f6d8a8239253c4da46e7abaa8584f8214d1828d2ff0a8f56176869"
-
-do_install_append () {
-	cd "${B}"
-	install -d "${D}${bindir}"
-	install -m755 "Release/bin/FileCheck" "${D}${bindir}"
-}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Grab the MACHINE from the environment; otherwise, set it to a sane default
-export MACHINE="${MACHINE-qemux86}"
+export MACHINE="${MACHINE-qemux86-64}"
 
 # What to build
 BUILD_TARGETS="\

--- a/scripts/containerize.sh
+++ b/scripts/containerize.sh
@@ -43,7 +43,7 @@ exec docker run \
     -e BUILD_UID=${my_uid} \
     -e BUILD_GID=${my_gid} \
     -e TEMPLATECONF=meta-rust/conf \
-    -e MACHINE=${MACHINE:-qemux86} \
+    -e MACHINE=${MACHINE:-qemux86-64} \
     ${SSH_AUTH_SOCK:+-e SSH_AUTH_SOCK="/tmp/ssh-agent/${SSH_AUTH_NAME}"} \
     -v ${HOME}/.ssh:/var/build/.ssh \
     -v "${PWD}":/var/build:rw \

--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -1,16 +1,23 @@
 #!/bin/bash -x
 
+# default repo
+if [[ $# -lt 1 ]]; then
+    echo "No Yocto branch specified, defaulting to master"
+    echo "To change this pass a Yocto branch name as an argument to this script"
+fi
+branch=${1-master}
+
 # the repos we want to check out, must setup variables below
 # NOTE: poky must remain first
 REPOS="poky metaoe"
 
 POKY_URI="git://git.yoctoproject.org/poky.git"
 POKY_PATH="poky"
-POKY_REV="${POKY_REV-refs/remotes/origin/$1}"
+POKY_REV="${POKY_REV-refs/remotes/origin/${branch}}"
 
 METAOE_URI="git://git.openembedded.org/meta-openembedded.git"
 METAOE_PATH="poky/meta-openembedded"
-METAOE_REV="${METAOE_REV-refs/remotes/origin/$1}"
+METAOE_REV="${METAOE_REV-refs/remotes/origin/${branch}}"
 
 METARUST_URI="."
 METARUST_PATH="poky/meta-rust"


### PR DESCRIPTION
Some additional cleanups I've queued after #101 lands.

- combine some `rust-llvm` bits that never made it into master and have been in fido and the starlab-io fork.
- fix the fetch script that Jenkins uses if a user decides to use it for testing to default to a sensible value
- change the default target machine to x86_64 from i586.

This is based on #101.