### PR TITLE
cargo: fix target system when building project

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -60,11 +60,11 @@ export RUST_BUILD_CC = "${CCACHE}${BUILD_PREFIX}gcc"
 export RUST_BUILD_CFLAGS = "${BUILD_CC_ARCH} ${BUILD_CFLAGS}"
 
 RUSTFLAGS ??= ""
-export CARGO_BUILD_FLAGS = "-v --target ${HOST_SYS} --release"
+export CARGO_BUILD_FLAGS = "-v --target ${TARGET_SYS} --release"
 
 # This is based on the content of CARGO_BUILD_FLAGS and generally will need to
 # change if CARGO_BUILD_FLAGS changes.
-export CARGO_TARGET_SUBDIR="${HOST_SYS}/release"
+export CARGO_TARGET_SUBDIR="${TARGET_SYS}/release"
 oe_cargo_build () {
 	export RUSTFLAGS="${RUSTFLAGS}"
 	bbnote "cargo = $(which cargo)"

--- a/recipes-devtools/rust/compiler-rt_1.10.0.bb
+++ b/recipes-devtools/rust/compiler-rt_1.10.0.bb
@@ -19,7 +19,7 @@ do_compile () {
 	oe_runmake -C ${S} \
 		ProjSrcRoot="${S}" \
 		ProjObjRoot="${B}" \
-		TargetTriple=${HOST_SYS} \
+		TargetTriple=${TARGET_SYS} \
 		triple-builtins
 }
 


### PR DESCRIPTION
This appears to be building for the wrong system and should be building
for the target.