### PR TITLE
github: add issue template to encourage reporting meta-rust version

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Version(s) of meta-rust
+
+## Version(s) of poky and/or oe-core
+
+## Expected result
+
+## Actual result
+
+## Steps to reproduce


### PR DESCRIPTION
I don't think we really need much structure, but in many cases
establishing the version of meta-rust which contains the issue is very
helpful in resolving it.

This makes it so the issue-reporter is at least given a field which
asks for the version.