### PR TITLE
Improve Rust triple generation

### DIFF
--- a/classes/rust-triples.bbclass
+++ b/classes/rust-triples.bbclass
@@ -9,10 +9,9 @@ def rust_base_triple(d, thing):
     '''
 
     arch = d.getVar('{}_ARCH'.format(thing), True)
-    vendor = d.getVar('{}_VENDOR'.format(thing), True)
-    os = d.getVar('{}_OS'.format(thing), True)
-
+    # All the Yocto targets are Linux and are 'unknown'
     vendor = "-unknown"
+    os = d.getVar('{}_OS'.format(thing), True)
 
     if arch.startswith("arm"):
         if os.endswith("gnueabi"):

--- a/classes/rust-triples.bbclass
+++ b/classes/rust-triples.bbclass
@@ -1,0 +1,31 @@
+# Responseible for taking Yocto triples and converting it to Rust triples
+
+def rust_base_triple(d, thing):
+    '''
+    Mangle bitbake's *_SYS into something that rust might support (see
+    rust/mk/cfg/* for a list)
+
+    Note that os is assumed to be some linux form
+    '''
+
+    arch = d.getVar('{}_ARCH'.format(thing), True)
+    vendor = d.getVar('{}_VENDOR'.format(thing), True)
+    os = d.getVar('{}_OS'.format(thing), True)
+
+    vendor = "-unknown"
+
+    if arch.startswith("arm"):
+        if os.endswith("gnueabi"):
+            os += bb.utils.contains('TUNE_FEATURES', 'callconvention-hard', 'hf', '', d)
+    elif arch.startswith("aarch64"):
+        os = "linux-gnu"
+    elif arch.startswith("x86_64"):
+        os = "linux-gnu"
+    elif arch.startswith("i586"):
+        arch = "i686"
+        os = "linux-gnu"
+    return arch + vendor + '-' + os
+
+RUST_BUILD_SYS = "${@rust_base_triple(d, 'BUILD')}"
+RUST_HOST_SYS = "${@rust_base_triple(d, 'HOST')}"
+RUST_TARGET_SYS = "${@rust_base_triple(d, 'TARGET')}"

--- a/classes/rust-triples.bbclass
+++ b/classes/rust-triples.bbclass
@@ -12,18 +12,24 @@ def rust_base_triple(d, thing):
     # All the Yocto targets are Linux and are 'unknown'
     vendor = "-unknown"
     os = d.getVar('{}_OS'.format(thing), True)
+    libc = d.getVar('TCLIBC', True)
 
-    if arch.startswith("arm"):
-        if os.endswith("gnueabi"):
-            os += bb.utils.contains('TUNE_FEATURES', 'callconvention-hard', 'hf', '', d)
-    elif arch.startswith("aarch64"):
-        os = "linux-gnu"
-    elif arch.startswith("x86_64"):
-        os = "linux-gnu"
-    elif arch.startswith("i586"):
-        arch = "i686"
-        os = "linux-gnu"
-    return arch + vendor + '-' + os
+    # Prefix with a dash and convert glibc -> gnu
+    if libc == "glibc":
+        libc = "-gnu"
+    elif libc == "musl":
+        libc = "-musl"
+
+    # Don't double up musl (only appears to be the case on aarch64)
+    if os == "linux-musl":
+        if libc != "-musl":
+            bb.fatal("{}_OS was '{}' but TCLIBC was not 'musl'".format(thing, os))
+        os = "linux"
+
+    # This catches ARM targets and appends the necessary hard float bits
+    if os == "linux-gnueabi" or os == "linux-musleabi":
+        libc = bb.utils.contains('TUNE_FEATURES', 'callconvention-hard', 'hf', '', d)
+    return arch + vendor + '-' + os + libc
 
 RUST_BUILD_SYS = "${@rust_base_triple(d, 'BUILD')}"
 RUST_HOST_SYS = "${@rust_base_triple(d, 'HOST')}"

--- a/classes/rust.bbclass
+++ b/classes/rust.bbclass
@@ -1,4 +1,5 @@
 inherit rust-vars
+inherit rust-triples
 
 RUSTC = "rustc"
 
@@ -16,36 +17,6 @@ def rust_base_dep(d):
     return deps
 
 DEPENDS_append = " ${@rust_base_dep(d)} patchelf-native"
-
-def rust_base_triple(d, thing):
-    '''
-    Mangle bitbake's *_SYS into something that rust might support (see
-    rust/mk/cfg/* for a list)
-
-    Note that os is assumed to be some linux form
-    '''
-
-    arch = d.getVar('{}_ARCH'.format(thing), True)
-    vendor = d.getVar('{}_VENDOR'.format(thing), True)
-    os = d.getVar('{}_OS'.format(thing), True)
-
-    vendor = "-unknown"
-
-    if arch.startswith("arm"):
-        if os.endswith("gnueabi"):
-            os += bb.utils.contains('TUNE_FEATURES', 'callconvention-hard', 'hf', '', d)
-    elif arch.startswith("aarch64"):
-        os = "linux-gnu"
-    elif arch.startswith("x86_64"):
-        os = "linux-gnu"
-    elif arch.startswith("i586"):
-        arch = "i686"
-        os = "linux-gnu"
-    return arch + vendor + '-' + os
-
-RUST_BUILD_SYS = "${@rust_base_triple(d, 'BUILD')}"
-RUST_HOST_SYS = "${@rust_base_triple(d, 'HOST')}"
-RUST_TARGET_SYS = "${@rust_base_triple(d, 'TARGET')}"
 
 # BUILD_LDFLAGS
 # 	${STAGING_LIBDIR_NATIVE}

--- a/classes/rust.bbclass
+++ b/classes/rust.bbclass
@@ -2,7 +2,7 @@ inherit rust-vars
 
 RUSTC = "rustc"
 
-RUSTC_ARCHFLAGS += "--target=${TARGET_SYS} ${RUSTFLAGS}"
+RUSTC_ARCHFLAGS += "--target=${HOST_SYS} ${RUSTFLAGS}"
 
 def rust_base_dep(d):
     # Taken from meta/classes/base.bbclass `base_dep_prepend` and modified to


### PR DESCRIPTION
Improve how we generate the native Rust triples from `TARGET_SYS`, `BUILD_SYS`, and `HOST_SYS` to hopefully more accurately generate these. This should solve issues with i586/i686 and musl based systems. Hopefully this future proofs the behavior for further support landing in upstream.