### PR TITLE
Update compiler-rt build and remove commented out bits

### DIFF
--- a/classes/rust.bbclass
+++ b/classes/rust.bbclass
@@ -31,18 +31,6 @@ DEPENDS_append = " ${@rust_base_dep(d)} patchelf-native"
 #	-L${STAGING_BASE_LIBDIR_NATIVE}	\
 #"
 
-RUST_PATH_NATIVE = "${STAGING_LIBDIR_NATIVE}:${STAGING_BASE_LIBDIR_NATIVE}"
-
-## Note: the 'rustlib' element of this was a workaround rustc forgetting the
-## libdir it was built with. It now remembers so this should be unneeded
-#RUST_PATH_NATIVE .= ":${STAGING_LIBDIR_NATIVE}/${TARGET_SYS}/rustlib/${TARGET_SYS}/lib"
-
-# FIXME: set based on whether we are native vs cross vs buildsdk, etc
-#export RUST_PATH ??= "${RUST_PATH_NATIVE}"
-
-## This is builtin to rustc with the value "$libdir/rust/targets"
-# RUST_TARGET_PATH = "foo:bar"
-
 oe_runrustc () {
 	bbnote ${RUSTC} ${RUSTC_ARCHFLAGS} ${RUSTC_FLAGS} "$@"
 	"${RUSTC}" ${RUSTC_ARCHFLAGS} ${RUSTC_FLAGS} "$@"

--- a/recipes-devtools/rust/compiler-rt_1.10.0.bb
+++ b/recipes-devtools/rust/compiler-rt_1.10.0.bb
@@ -12,13 +12,14 @@ require rust-source-${PV}.inc
 
 S = "${WORKDIR}/rustc-${PV}/src/compiler-rt"
 
-# Pick up $CC from the environment
-EXTRA_OEMAKE += "-e"
-
 do_compile () {
 	oe_runmake -C ${S} \
 		ProjSrcRoot="${S}" \
 		ProjObjRoot="${B}" \
+		CC="${CC}" \
+		AR="${AR}" \
+		RANLIB="${RANLIB}" \
+		CFLAGS="${CFLAGS}" \
 		TargetTriple=${HOST_SYS} \
 		triple-builtins
 }

--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -415,7 +415,6 @@ do_configure () {
 
 rust_runmake () {
     echo "COMPILE ${PN}" "$@"
-    env
 
     # CFLAGS, LDFLAGS, CXXFLAGS, CPPFLAGS are used by rust's build for a
     # wide range of targets (not just TARGET). Yocto's settings for them will


### PR DESCRIPTION
Found some commented out bits that can just get cleaned up. Removed a call to `env` that was dumping into the logs. And lastly updated compiler-rt to be built closer to how upstream builds it instead of passing in the entire environment in.