### PR TITLE
refactor linker flags out of custom targets

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ for (int i = 0; i < targets.size(); i++) {
                     sh "./scripts/setup-env.sh"
                 }
                 stage('Yocto Fetch') {
-                    sh "GIT_LOCAL_REF_DIR=/srv/git-cache/ ./scripts/fetch.sh master"
+                    sh "GIT_LOCAL_REF_DIR=/srv/git-cache/ ./scripts/fetch.sh morty"
                 }
                 stage('Build') {
                     sh "MACHINE=${machine} ./scripts/build.sh"

--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -60,11 +60,11 @@ export RUST_BUILD_CC = "${CCACHE}${BUILD_PREFIX}gcc"
 export RUST_BUILD_CFLAGS = "${BUILD_CC_ARCH} ${BUILD_CFLAGS}"
 
 RUSTFLAGS ??= ""
-export CARGO_BUILD_FLAGS = "-v --target ${HOST_SYS} --release"
+CARGO_BUILD_FLAGS = "-v --target ${HOST_SYS} --release"
 
 # This is based on the content of CARGO_BUILD_FLAGS and generally will need to
 # change if CARGO_BUILD_FLAGS changes.
-export CARGO_TARGET_SUBDIR="${HOST_SYS}/release"
+CARGO_TARGET_SUBDIR="${HOST_SYS}/release"
 oe_cargo_build () {
 	export RUSTFLAGS="${RUSTFLAGS}"
 	bbnote "cargo = $(which cargo)"

--- a/recipes-devtools/cargo/cargo.inc
+++ b/recipes-devtools/cargo/cargo.inc
@@ -67,6 +67,10 @@ SRC_URI = "\
 
 B = "${S}"
 
+# Can't use the default from rust-vars as it cause a compiler crash
+# the crate_hash option will cause the compiler to crash
+RUSTFLAGS = "-C rpath ${RUSTLIB}"
+
 PACKAGECONFIG ??= ""
 
 # Note: this does not appear to work very well due to our use of bitbake triples

--- a/recipes-devtools/cargo/cargo.inc
+++ b/recipes-devtools/cargo/cargo.inc
@@ -71,12 +71,6 @@ B = "${S}"
 # the crate_hash option will cause the compiler to crash
 RUSTFLAGS = "-C rpath ${RUSTLIB}"
 
-PACKAGECONFIG ??= ""
-
-# Note: this does not appear to work very well due to our use of bitbake triples
-# & rust's use of cooked triples
-PACKAGECONFIG[rust-snapshot] = "--local-rust-root=${B}/rustc"
-
 # Used in libgit2-sys's build.rs, needed for pkg-config to be used
 export LIBGIT2_SYS_USE_PKG_CONFIG = "1"
 
@@ -84,8 +78,6 @@ export LIBGIT2_SYS_USE_PKG_CONFIG = "1"
 DISABLE_STATIC = ""
 
 do_configure () {
-	${@bb.utils.contains('PACKAGECONFIG', 'rust-snapshot', '${S}/.travis.install.deps.sh', ':', d)}
-
 	"${S}/configure" \
 		"--prefix=${prefix}"			\
 		"--build=${BUILD_SYS}"			\

--- a/recipes-devtools/cargo/cargo.inc
+++ b/recipes-devtools/cargo/cargo.inc
@@ -107,7 +107,7 @@ do_compile () {
 	mkdir -p target
 	cp -R ${WORKDIR}/cargo-nightly-x86_64-unknown-linux-gnu/cargo target/snapshot
 
-	oe_runmake ARGS="--verbose"
+	oe_runmake VERBOSE=1
 }
 
 do_install () {

--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -119,45 +119,29 @@ LLVM_TARGET[arm] = "${RUST_TARGET_SYS}"
 TARGET_ENDIAN[arm] = "little"
 TARGET_POINTER_WIDTH[arm] = "32"
 FEATURES[arm] = "+v6,+vfp2"
-PRE_LINK_ARGS[arm] = "-Wl,--as-needed"
 
 DATA_LAYOUT[aarch64] = "e-m:e-i64:64-i128:128-n32:64-S128"
 LLVM_TARGET[aarch64] = "aarch64-unknown-linux-gnu"
 TARGET_ENDIAN[aarch64] = "little"
 TARGET_POINTER_WIDTH[aarch64] = "64"
-PRE_LINK_ARGS[aarch64] = "-Wl,--as-needed"
 
 ## x86_64-unknown-linux-gnu
 DATA_LAYOUT[x86_64] = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 LLVM_TARGET[x86_64] = "x86_64-unknown-linux-gnu"
 TARGET_ENDIAN[x86_64] = "little"
 TARGET_POINTER_WIDTH[x86_64] = "64"
-PRE_LINK_ARGS[x86_64] = "-Wl,--as-needed -m64"
 
 ## i686-unknown-linux-gnu
 DATA_LAYOUT[i686] = "e-m:e-p:32:32-f64:32:64-f80:32-n8:16:32-S128"
 LLVM_TARGET[i686] = "i686-unknown-linux-gnu"
 TARGET_ENDIAN[i686] = "little"
 TARGET_POINTER_WIDTH[i686] = "32"
-PRE_LINK_ARGS[i686] = "-Wl,--as-needed -m32"
 
 ## XXX: a bit of a hack so qemux86 builds, clone of i686-unknown-linux-gnu above
 DATA_LAYOUT[i586] = "e-m:e-p:32:32-f64:32:64-f80:32-n8:16:32-S128"
 LLVM_TARGET[i586] = "i586-unknown-linux-gnu"
 TARGET_ENDIAN[i586] = "little"
 TARGET_POINTER_WIDTH[i586] = "32"
-PRE_LINK_ARGS[i586] = "-Wl,--as-needed -m32"
-
-TARGET_PRE_LINK_ARGS = "${TARGET_CC_ARCH} ${TOOLCHAIN_OPTIONS}"
-BUILD_PRE_LINK_ARGS = "${BUILD_CC_ARCH} ${TOOLCHAIN_OPTIONS}"
-HOST_PRE_LINK_ARGS = "${HOST_CC_ARCH} ${TOOLCHAIN_OPTIONS}"
-
-# These LDFLAGS have '-L' options in them. We need these to come last so they
-# don't screw up the link order and pull in the wrong rust build/version.
-# TODO: may want to strip out all the '-L' flags entirely here
-TARGET_POST_LINK_ARGS = "${TARGET_LDFLAGS}"
-BUILD_POST_LINK_ARGS = "${BUILD_LDFLAGS}"
-HOST_POST_LINK_ARGS = "${HOST_LDFLAGS}"
 
 def arch_for(d, thing):
     return d.getVar('{}_ARCH'.format(thing), True)
@@ -208,21 +192,6 @@ def llvm_cpu(d):
     except:
         return trans.get(target, "generic")
 
-def post_link_args_for(d, thing, arch):
-    post_link_args = (d.getVar('{}_POST_LINK_ARGS'.format(thing), True) or "").split()
-    post_link_args.extend((d.getVarFlag('POST_LINK_ARGS', arch, True) or "").split())
-    return post_link_args
-
-def pre_link_args_for(d, thing, arch):
-    ldflags = (d.getVar('{}_PRE_LINK_ARGS'.format(thing), True) or "").split()
-    ldflags.extend((d.getVarFlag('PRE_LINK_ARGS', arch, True) or "").split())
-    return ldflags
-
-def ldflags_for(d, thing, arch):
-    a = pre_link_args_for(d, thing, arch)
-    a.extend(post_link_args_for(d, thing, arch))
-    return a
-
 TARGET_LLVM_CPU="${@llvm_cpu(d)}"
 TARGET_LLVM_FEATURES = "${@llvm_features_from_tune(d)} ${@llvm_features_from_cc_arch(d)}"
 
@@ -267,8 +236,6 @@ def rust_gen_target(d, thing, wd):
     tspec['has-rpath'] = True
     tspec['has-elf-tls'] = True
     tspec['position-independent-executables'] = True
-    tspec['pre-link-args'] = pre_link_args_for(d, thing, arch)
-    tspec['post-link-args'] = post_link_args_for(d, thing, arch)
 
     # write out the target spec json file
     with open(wd + sys + '.json', 'w') as f:
@@ -306,7 +273,7 @@ def rust_gen_mk_cfg(d, thing):
     sys = sys_for(d, thing)
     prefix = prefix_for(d, thing)
     llvm_target = d.getVarFlag('LLVM_TARGET', arch, True)
-    ldflags = ' '.join(ldflags_for(d, thing, arch))
+    ldflags = d.getVar('LDFLAGS', True) + d.getVar('HOST_CC_ARCH', True) + d.getVar('TOOLCHAIN_OPTIONS', True)
 
     b = d.getVar('WORKDIR', True) + '/mk-cfg/'
     o = open(b + sys_for(d, thing) + '.mk', 'w')


### PR DESCRIPTION
Refactors the Yocto linker flags out of the custom targets and into the rustflags option of the cargo config. This is part of my series to eventually allow us to use the native targets and slim down the delta between upstream Rust/Cargo and what's in meta-rust.