### PR TITLE
workaround bug in the -C crate_hash option

### DIFF
--- a/classes/rust-bin.bbclass
+++ b/classes/rust-bin.bbclass
@@ -3,6 +3,7 @@ inherit rust
 DEPENDS_append = " patchelf-native"
 RDEPENDS_${PN} += "${RUSTLIB_DEP}"
 
+RUSTFLAGS += "-C crate_hash=${BB_TASKHASH}"
 RUSTC_ARCHFLAGS += "-C opt-level=3 -g -L ${STAGING_DIR_HOST}/${rustlibdir}"
 EXTRA_OEMAKE += 'RUSTC_ARCHFLAGS="${RUSTC_ARCHFLAGS}"'
 

--- a/classes/rust-common.bbclass
+++ b/classes/rust-common.bbclass
@@ -5,7 +5,7 @@ FILES_${PN}-dev += "${rustlibdir}/*.rlib"
 FILES_${PN}-dbg += "${rustlibdir}/.debug"
 
 RUSTLIB = "-L ${STAGING_LIBDIR}/rust"
-RUSTFLAGS += "-C rpath -C crate_hash=${BB_TASKHASH} ${RUSTLIB}"
+RUSTFLAGS += "-C rpath ${RUSTLIB}"
 RUSTLIB_DEP ?= "libstd-rs"
 
 # Responsible for taking Yocto triples and converting it to Rust triples


### PR DESCRIPTION
The -C crate_hash option does not work if multiple versions of the same
crate are being linked into a binary. This can happen if different
dependencies depend on different versions of the same crate. The -C
crate_hash argument causes all versions of a given crate to have the
same crate hash which in turn causes the compiler to select the wrong
one internally and crash. This works around issue #126 for Cargo builds
but does not fix the underlying cause.