### PR TITLE
compiler-rt: fix toolchain installer

### DIFF
--- a/recipes-devtools/rust/compiler-rt_1.10.0.bb
+++ b/recipes-devtools/rust/compiler-rt_1.10.0.bb
@@ -10,6 +10,12 @@ SRC_URI = "\
 
 require rust-source-${PV}.inc
 
+ALLOW_EMPTY_${PN} = "1"
+
+# dev and staticdev should NOT depend on the binary package
+RDEPENDS_${PN}-dev = ""
+INSANE_SKIP_${PN}-dev = "staticdev"
+
 S = "${WORKDIR}/rustc-${PV}/src/compiler-rt"
 
 do_compile () {
@@ -28,3 +34,6 @@ do_install () {
 	mkdir -p ${D}${libdir}
 	cp triple/builtins/libcompiler_rt.a ${D}${libdir}/libcompiler-rt.a
 }
+
+FILES_${PN}-dev = ""
+FILES_${PN}-staticdev = "${libdir}/*.a"

--- a/recipes-devtools/rust/compiler-rt_1.12.1.bb
+++ b/recipes-devtools/rust/compiler-rt_1.12.1.bb
@@ -6,8 +6,12 @@ LIC_FILES_CHKSUM = "file://src/compiler-rt/LICENSE.TXT;md5=bf24bca27049b52e97384
 
 require rust.inc
 require rust-source-${PV}.inc
+ALLOW_EMPTY_${PN} = "1"
 
 DEPENDS += "rust-llvm-native (=${PV})"
+# dev and staticdev should NOT depend on the binary package
+RDEPENDS_${PN}-dev = ""
+INSANE_SKIP_${PN}-dev = "staticdev"
 
 S = "${WORKDIR}/rustc-${PV}"
 
@@ -22,3 +26,6 @@ do_install () {
 	mkdir -p ${D}${libdir}
 	cp ${TARGET_SYS}/rt/libcompiler-rt.a ${D}${libdir}/libcompiler-rt.a
 }
+
+FILES_${PN}-dev = ""
+FILES_${PN}-staticdev = "${libdir}/*.a"


### PR DESCRIPTION
Fix building a toolchain installer with bitbake
-c populate_sdk in packages compiler-rt,
compiler-rt-dev and compiler-rt-staticdev.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>