### PR TITLE
rust: fix cpu selection so older processors can run executables for rust-native

### DIFF
--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -177,7 +177,7 @@ def arch_to_rust_target_arch(arch):
 
 # generates our target CPU value
 def llvm_cpu(d):
-    cpu = d.getVar('TUNE_PKGARCH', True)
+    cpu = d.getVar('PACKAGE_ARCH', True)
     target = d.getVar('TRANSLATED_TARGET_ARCH', True)
 
     trans = {}


### PR DESCRIPTION
Resolves #139 