### PR TITLE
Make builds reproducible for sstate

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -13,6 +13,7 @@ BASEDEPENDS_append = " cargo-native"
 
 # Ensure we get the right rust variant
 DEPENDS_append_class-target = " virtual/${TARGET_PREFIX}rust ${RUSTLIB_DEP}"
+RDEPENDS_${PN}_append_class-target = " ${RUSTLIB_DEP}"
 DEPENDS_append_class-native = " rust-native"
 
 # Cargo only supports in-tree builds at the moment

--- a/classes/force-crate-hash.bbclass
+++ b/classes/force-crate-hash.bbclass
@@ -1,0 +1,1 @@
+RUSTFLAGS += "-C crate_hash=${BB_TASKHASH}"

--- a/classes/rust-bin.bbclass
+++ b/classes/rust-bin.bbclass
@@ -1,9 +1,9 @@
 inherit rust
+inherit force-crate-hash
 
 DEPENDS_append = " patchelf-native"
 RDEPENDS_${PN} += "${RUSTLIB_DEP}"
 
-RUSTFLAGS += "-C crate_hash=${BB_TASKHASH}"
 RUSTC_ARCHFLAGS += "-C opt-level=3 -g -L ${STAGING_DIR_HOST}/${rustlibdir}"
 EXTRA_OEMAKE += 'RUSTC_ARCHFLAGS="${RUSTC_ARCHFLAGS}"'
 

--- a/recipes-devtools/cargo/cargo.inc
+++ b/recipes-devtools/cargo/cargo.inc
@@ -10,6 +10,7 @@ DEPENDS = "openssl zlib libgit2 curl ca-certificates libssh2"
 
 SRC_URI = "\
 	http://static-rust-lang-org.s3.amazonaws.com/cargo-dist/${CARGO_SNAPSHOT} \
+	file://0001-Don-t-hash-source_id.patch \
 "
 
 B = "${S}"

--- a/recipes-devtools/cargo/cargo/0001-Don-t-hash-source_id.patch
+++ b/recipes-devtools/cargo/cargo/0001-Don-t-hash-source_id.patch
@@ -1,0 +1,27 @@
+From a65784be8fdbc7dffa6d568bcc364cb67655ebfe Mon Sep 17 00:00:00 2001
+From: Steven Walter <stevenrwalter@gmail.com>
+Date: Fri, 27 Jan 2017 11:24:57 -0500
+Subject: [PATCH] Don't hash source_id
+
+This makes hashes reproducible when building directly in the source as
+well as from a registry. Reproducible file names are necessary for
+linking against externally built crates.
+---
+ src/cargo/core/package_id.rs | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/cargo/core/package_id.rs b/src/cargo/core/package_id.rs
+index b29b8ca..7691d38 100644
+--- a/src/cargo/core/package_id.rs
++++ b/src/cargo/core/package_id.rs
+@@ -66,7 +66,6 @@ impl Hash for PackageId {
+     fn hash<S: hash::Hasher>(&self, state: &mut S) {
+         self.inner.name.hash(state);
+         self.inner.version.hash(state);
+-        self.inner.source_id.hash(state);
+     }
+ }
+ 
+-- 
+2.7.4
+

--- a/recipes-devtools/rust/libstd-rs_1.12.1.bb
+++ b/recipes-devtools/rust/libstd-rs_1.12.1.bb
@@ -32,4 +32,5 @@ do_compile_prepend () {
 do_install () {
     mkdir -p ${D}${rustlibdir}
     cp ${B}/${TARGET_SYS}/release/deps/* ${D}${rustlibdir}
+    rm ${D}${rustlibdir}/libstd*.rlib
 }

--- a/recipes-devtools/rust/libstd-rs_1.12.1.bb
+++ b/recipes-devtools/rust/libstd-rs_1.12.1.bb
@@ -16,6 +16,7 @@ DEPENDS += "compiler-rt (=${PV})"
 
 RUSTLIB_DEP = ""
 inherit cargo
+inherit force-crate-hash
 
 # Needed so cargo can find libbacktrace
 RUSTFLAGS += "-L ${STAGING_LIBDIR}"


### PR DESCRIPTION
Without these commits I get various symbol / crate_hash mismatch errors when building.

It would be nice if we had a unit test to make sure we don't break sstate every time we upgrade rust.  In particular, if we built libstd-rs in two differently-named work dirs, we would have seen that the symbols have different names in each work directory, even though the bitbake task hash is the same.