### PR TITLE
rust-llvm.inc: work around build race

### DIFF
--- a/recipes-devtools/rust/rust-llvm.inc
+++ b/recipes-devtools/rust/rust-llvm.inc
@@ -80,6 +80,8 @@ do_compile_prepend_class-target() {
 }
 
 do_compile() {
+    oe_runmake NATIVE_LIB_LLVMTABLEGEN
+    oe_runmake NativeLLVMConfig
     oe_runmake
 }
 


### PR DESCRIPTION
The way LLVM builds its native utilities is not safe (it runs a
recursive cmake in the same work directory as the main instance).  To
prevent those instances from stepping on each other, we'll build the two
native utilities separately before starting the main build.

Fixes issue #143