### PR TITLE
Add the ability to use and store build cache artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,9 @@ for (int i = 0; i < targets.size(); i++) {
                 echo "Caught: ${e}"
                 throw e
             } finally {
+                stage("push build cache $machine") {
+                    sh "./scripts/publish-build-cache.sh master"
+                }
                 stage("cleanup $machine") {
                     sh "./scripts/cleanup-env.sh"
                     deleteDir()

--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -220,7 +220,7 @@ BB_DISKMON_DIRS = "\
 #file://.* http://someserver.tld/share/sstate/PATH;downloadfilename=PATH \n \
 #file://.* file:///some/local/dir/sstate/PATH"
 
-SSTATE_MIRRORS ?= "file://.* http://build-cache.asterius.io/sstate/PATH;downloadfilename=PATH \n"
+SSTATE_MIRRORS ?= "file://.* http://build-cache.asterius.io/master/sstate-cache/PATH;downloadfilename=PATH \n"
 
 SOURCE_MIRROR_URL ?= "http://build-cache.asterius.io/downloads/"
 INHERIT += "own-mirrors rm_work"

--- a/scripts/publish-build-cache.sh
+++ b/scripts/publish-build-cache.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+if [[ $# -lt 1 ]]; then
+    echo "No Yocto branch specified, defaulting to master"
+    echo "To change this pass a Yocto branch name as an argument to this script"
+fi
+branch=${1-master}
+
+rsync -avz -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --progress build/downloads yocto-cache@build-cache.asterius.io:/srv/yocto-cache/
+
+rsync -avz -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --progress build/sstate-cache yocto-cache@build-cache.asterius.io:/srv/yocto-cache/${branch}/
+
+exit 0


### PR DESCRIPTION
Before this PR, all builds would run without and use of SSTATE cache.  With this addition, the build times can be significantly reduced.