### PR TITLE
rust-llvm: Drop unnecessary native customization

### DIFF
--- a/recipes-devtools/rust/rust-llvm.inc
+++ b/recipes-devtools/rust/rust-llvm.inc
@@ -27,50 +27,6 @@ EXTRA_OECMAKE = " \
 # provide almost no value. If you really need them then override this
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 
-EXTRA_OECMAKE_append_class-target = "\
-  -DCROSS_TOOLCHAIN_FLAGS_NATIVE='-DCMAKE_TOOLCHAIN_FILE=${WORKDIR}/native_toolchain.cmake' \
-"
-
-do_generate_native_toolchain_file() {
-        cat > ${WORKDIR}/native_toolchain.cmake <<EOF
-set( CMAKE_SYSTEM_NAME `echo ${BUILD_OS} | sed -e 's/^./\u&/' -e 's/^\(Linux\).*/\1/'` )
-set( CMAKE_SYSTEM_PROCESSOR ${BUILD_ARCH} )
-set( CMAKE_C_COMPILER ${BUILD_CC} )
-set( CMAKE_CXX_COMPILER ${BUILD_CXX} )
-set( CMAKE_ASM_COMPILER ${BUILD_AS} )
-set( CMAKE_AR ${BUILD_AR} CACHE FILEPATH "Archiver" )
-set( CMAKE_C_FLAGS "${BUILD_CC_ARCH} ${BUILD_CFLAGS}" CACHE STRING "CFLAGS" )
-set( CMAKE_CXX_FLAGS "${BUILD_CC_ARCH} ${BUILD_CXXFLAGS}" CACHE STRING "CXXFLAGS" )
-set( CMAKE_ASM_FLAGS "${BUILD_CC_ARCH} ${BUILD_CFLAGS}" CACHE STRING "ASM FLAGS" )
-set( CMAKE_C_FLAGS_RELEASE "${SELECTED_OPTIMIZATION} ${BUILD_CFLAGS} -DNDEBUG" CACHE STRING "CFLAGS for release" )
-set( CMAKE_CXX_FLAGS_RELEASE "${SELECTED_OPTIMIZATION} ${BUILD_CXXFLAGS} -DNDEBUG" CACHE STRING "CXXFLAGS for release" )
-set( CMAKE_ASM_FLAGS_RELEASE "${SELECTED_OPTIMIZATION} ${BUILD_CFLAGS} -DNDEBUG" CACHE STRING "ASM FLAGS for release" )
-set( CMAKE_C_LINK_FLAGS "${BUILD_CC_ARCH} ${BUILD_CPPFLAGS} ${BUILD_LDFLAGS}" CACHE STRING "LDFLAGS" )
-set( CMAKE_CXX_LINK_FLAGS "${BUILD_CC_ARCH} ${BUILD_CXXFLAGS} ${BUILD_LDFLAGS}" CACHE STRING "LDFLAGS" )
-
-# only search in the paths provided so cmake doesnt pick
-# up libraries and tools from the native build machine
-set( CMAKE_FIND_ROOT_PATH ${STAGING_DIR_HOST} ${STAGING_DIR_NATIVE} ${CROSS_DIR} ${OECMAKE_PERLNATIVE_DIR} ${OECMAKE_EXTRA_ROOT_PATH} ${EXTERNAL_TOOLCHAIN})
-set( CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY )
-set( CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY )
-set( CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY )
-
-# Use native cmake modules
-set( CMAKE_MODULE_PATH ${STAGING_DATADIR}/cmake/Modules/ )
-
-# add for non /usr/lib libdir, e.g. /usr/lib64
-set( CMAKE_LIBRARY_PATH ${libdir} ${base_libdir})
-
-EOF
-}
-
-addtask generate_native_toolchain_file after do_patch before do_configure
-
-do_configure_prepend_class-native() {
-    # Use host paths for native tools
-    sed -i -e '/CMAKE_FIND_ROOT_PATH_MODE/d' ${WORKDIR}/toolchain.cmake
-}
-
 do_compile_prepend_class-target() {
     # Fix paths in llvm-config
     sed -i "s|sys::path::parent_path(CurrentPath))\.str()|sys::path::parent_path(sys::path::parent_path(CurrentPath))).str()|g" ${S}/tools/llvm-config/llvm-config.cpp
@@ -80,8 +36,6 @@ do_compile_prepend_class-target() {
 }
 
 do_compile() {
-    oe_runmake NATIVE_LIB_LLVMTABLEGEN
-    oe_runmake NativeLLVMConfig
     oe_runmake
 }
 

--- a/recipes-devtools/rust/rust-llvm_1.15.1.bb
+++ b/recipes-devtools/rust/rust-llvm_1.15.1.bb
@@ -1,7 +1,7 @@
 require rust-source-${PV}.inc
 require rust-llvm.inc
 
-LIC_FILES_CHKSUM = "file://LICENSE.TXT;md5=43fdaa303c1c5589ad60f4ffc6a0b9ce"
+LIC_FILES_CHKSUM = "file://LICENSE.TXT;md5=b99eb43c934ceebecab85c6b9b1a08be"
 
 do_install_prepend () {
 	# the install does a sed on this without installing the file


### PR DESCRIPTION
This is already accounted for by the LLVM CMake files, assuming
CMAKE_CROSSCOMPILING is set correctly, which is fixed in the upstream
cmake.bbclass.

http://git.openembedded.org/openembedded-core/commit/?id=bd082c9be6191e67ea1b1bf10ce5e130a3433ab5