### PR TITLE
rust-bin.bbclass fixes

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -24,7 +24,6 @@ export RUST_BACKTRACE = "1"
 
 RUSTFLAGS ??= ""
 CARGO_BUILD_FLAGS = "-v --target ${HOST_SYS} --release"
-RUST_TARGET_PATH = "${STAGING_LIBDIR_NATIVE}/rustlib"
 
 # This is based on the content of CARGO_BUILD_FLAGS and generally will need to
 # change if CARGO_BUILD_FLAGS changes.

--- a/classes/rust-bin.bbclass
+++ b/classes/rust-bin.bbclass
@@ -1,6 +1,5 @@
 inherit rust
 
-DEPENDS_append = " patchelf-native"
 RDEPENDS_${PN} += "${RUSTLIB_DEP}"
 
 RUSTC_ARCHFLAGS += "-C opt-level=3 -g -L ${STAGING_DIR_HOST}/${rustlibdir} -C linker=${RUST_TARGET_CCLD}"
@@ -37,6 +36,44 @@ CRATE_TYPE ?= "dylib"
 BIN_SRC ?= "${S}/src/main.rs"
 LIB_SRC ?= "${S}/src/lib.rs"
 
+rustbindest ?= "${bindir}"
+rustlibdest ?= "${rustlibdir}"
+RUST_RPATH_ABS ?= "${rustlibdir}:${rustlib}"
+
+def relative_rpaths(paths, base):
+    relpaths = set()
+    for p in paths.split(':'):
+        if p == base:
+            relpaths.add('$ORIGIN')
+            continue
+        relpaths.add(os.path.join('$ORIGIN', os.path.relpath(p, base)))
+    return '-rpath=' + ':'.join(relpaths) if len(relpaths) else ''
+
+RUST_LIB_RPATH_FLAGS ?= "${@relative_rpaths(d.getVar('RUST_RPATH_ABS', True), d.getVar('rustlibdest', True))}"
+RUST_BIN_RPATH_FLAGS ?= "${@relative_rpaths(d.getVar('RUST_RPATH_ABS', True), d.getVar('rustbindest', True))}"
+
+def libfilename(d):
+    if d.getVar('CRATE_TYPE', True) == 'dylib':
+        return d.getVar('LIBNAME', True) + '.so'
+    else:
+        return d.getVar('LIBNAME', True) + '.rlib'
+
+def link_args(d, bin):
+    linkargs = []
+    if bin:
+        rpaths = d.getVar('RUST_BIN_RPATH_FLAGS', False)
+    else:
+        rpaths = d.getVar('RUST_LIB_RPATH_FLAGS', False)
+        if d.getVar('CRATE_TYPE', True) == 'dylib':
+            linkargs.append('-soname')
+            linkargs.append(libfilename(d))
+    if len(rpaths):
+        linkargs.append(rpaths)
+    if len(linkargs):
+        return ' '.join(['-Wl,' + arg for arg in linkargs])
+    else:
+        return ''
+
 get_overlap_externs () {
     externs=
     for dep in ${OVERLAP_DEPS}; do
@@ -62,17 +99,16 @@ oe_runrustc () {
 }
 
 oe_compile_rust_lib () {
-    [ "${CRATE_TYPE}" == "dylib" ] && suffix=so || suffix=rlib
     rm -rf ${LIBNAME}.{rlib,so}
     local -a link_args
-    if [ "${CRATE_TYPE}" == "dylib" ]; then
-        link_args[0]="-C"
-        link_args[1]="link-args=-Wl,-soname -Wl,${LIBNAME}.$suffix"
+    if [ -n '${@link_args(d, False)}' ]; then
+        link_args[0]='-C'
+        link_args[1]='link-args=${@link_args(d, False)}'
     fi
     oe_runrustc $(get_overlap_externs) \
         "${link_args[@]}" \
         ${LIB_SRC} \
-        -o ${LIBNAME}.$suffix \
+        -o ${@libfilename(d)} \
         --crate-name=${CRATE_NAME} --crate-type=${CRATE_TYPE} \
         "$@"
 }
@@ -80,33 +116,33 @@ oe_compile_rust_lib[vardeps] += "get_overlap_externs"
 
 oe_compile_rust_bin () {
     rm -rf ${BINNAME}
-    oe_runrustc $(get_overlap_externs) ${BIN_SRC} -o ${BINNAME} "$@"
+    local -a link_args
+    if [ -n '${@link_args(d, True)}' ]; then
+        link_args[0]='-C'
+        link_args[1]='link-args=${@link_args(d, True)}'
+    fi
+    oe_runrustc $(get_overlap_externs) \
+        "${link_args[@]}" \
+        ${BIN_SRC} -o ${BINNAME} "$@"
 }
 oe_compile_rust_bin[vardeps] += "get_overlap_externs"
 
 oe_install_rust_lib () {
     for lib in $(ls ${LIBNAME}.{so,rlib} 2>/dev/null); do
         echo Installing $lib
-        install -D -m 755 $lib ${D}/${rustlibdir}/$lib
+        install -D -m 755 $lib ${D}/${rustlibdest}/$lib
     done
 }
 
 oe_install_rust_bin () {
     echo Installing ${BINNAME}
-    install -D -m 755 ${BINNAME} ${D}/${bindir}/${BINNAME}
+    install -D -m 755 ${BINNAME} ${D}/${rustbindest}/${BINNAME}
 }
 
 do_rust_bin_fixups() {
     for f in `find ${PKGD} -name '*.so*'`; do
         echo "Strip rust note: $f"
         ${OBJCOPY} -R .note.rustc $f $f
-    done
-
-    for f in `find ${PKGD}`; do
-        file "$f" | grep -q ELF || continue
-        readelf -d "$f" | grep RUNPATH | grep -q rustlib || continue
-        echo "Set rpath:" "$f"
-        patchelf --set-rpath '$ORIGIN:'${rustlibdir}:${rustlib} "$f"
     done
 }
 PACKAGE_PREPROCESS_FUNCS += "do_rust_bin_fixups"

--- a/classes/rust-bin.bbclass
+++ b/classes/rust-bin.bbclass
@@ -3,7 +3,7 @@ inherit rust
 DEPENDS_append = " patchelf-native"
 RDEPENDS_${PN} += "${RUSTLIB_DEP}"
 
-RUSTC_ARCHFLAGS += "-C opt-level=3 -g -L ${STAGING_DIR_HOST}/${rustlibdir} -C link-args=--sysroot=${STAGING_DIR_HOST}"
+RUSTC_ARCHFLAGS += "-C opt-level=3 -g -L ${STAGING_DIR_HOST}/${rustlibdir} -C linker=${RUST_TARGET_CCLD}"
 EXTRA_OEMAKE += 'RUSTC_ARCHFLAGS="${RUSTC_ARCHFLAGS}"'
 
 # Some libraries alias with the standard library but libstd is configured to

--- a/classes/rust-bin.bbclass
+++ b/classes/rust-bin.bbclass
@@ -56,6 +56,7 @@ do_configure () {
 }
 
 oe_runrustc () {
+	export RUST_TARGET_PATH="${RUST_TARGET_PATH}"
 	bbnote ${RUSTC} ${RUSTC_ARCHFLAGS} ${RUSTC_FLAGS} "$@"
 	"${RUSTC}" ${RUSTC_ARCHFLAGS} ${RUSTC_FLAGS} "$@"
 }

--- a/classes/rust-bin.bbclass
+++ b/classes/rust-bin.bbclass
@@ -1,6 +1,6 @@
 inherit rust
 
-RDEPENDS_${PN} += "${RUSTLIB_DEP}"
+RDEPENDS_${PN}_append_class-target += "${RUSTLIB_DEP}"
 
 RUSTC_ARCHFLAGS += "-C opt-level=3 -g -L ${STAGING_DIR_HOST}/${rustlibdir} -C linker=${RUST_TARGET_CCLD}"
 EXTRA_OEMAKE += 'RUSTC_ARCHFLAGS="${RUSTC_ARCHFLAGS}"'

--- a/classes/rust-common.bbclass
+++ b/classes/rust-common.bbclass
@@ -7,6 +7,7 @@ FILES_${PN}-dbg += "${rustlibdir}/.debug"
 RUSTLIB = "-L ${STAGING_LIBDIR}/rust"
 RUSTFLAGS += "${RUSTLIB}"
 RUSTLIB_DEP ?= "libstd-rs"
+RUST_TARGET_PATH = "${STAGING_LIBDIR_NATIVE}/rustlib"
 
 # Responsible for taking Yocto triples and converting it to Rust triples
 

--- a/classes/rust.bbclass
+++ b/classes/rust.bbclass
@@ -42,3 +42,4 @@ rustlib_suffix="${TUNE_ARCH}${TARGET_VENDOR}-${TARGET_OS}/rustlib/${HOST_SYS}/li
 rustlib_src="${prefix}/lib/${rustlib_suffix}"
 # Host sysroot standard library path
 rustlib="${libdir}/${rustlib_suffix}"
+rustlib_class-native="${libdir}/rustlib/${BUILD_SYS}/lib"

--- a/recipes-core/aho-corasick/aho-corasick-rs_0.2.1.bb
+++ b/recipes-core/aho-corasick/aho-corasick-rs_0.2.1.bb
@@ -18,3 +18,5 @@ do_compile () {
 do_install () {
 	oe_install_rust_lib
 }
+
+BBCLASSEXTEND += "native"

--- a/recipes-core/bitflags/bitflags_0.8.2.bb
+++ b/recipes-core/bitflags/bitflags_0.8.2.bb
@@ -8,12 +8,14 @@ LIC_FILES_CHKSUM = "\
 
 inherit rust-bin
 
-SRC_URI = "git://github.com/rust-lang-nursery/bitflags.git;protocol=https"
-SRCREV = "41aa413a7c30d70b93b44ab5447276c381ef249e"
+SRC_URI = "git://github.com/rust-lang-nursery/bitflags.git;protocol=https;nobranch=1"
+SRCREV = "e30da43cac0e52fc8d0007ce99a316ec6473033e"
 
 S = "${WORKDIR}/git"
 
 LIB_SRC = "${S}/src/lib.rs"
+CRATE_TYPE = "rlib"
+RUSTFLAGS += "-A pub_use_of_private_extern_crate"
 
 do_compile () {
 	oe_compile_rust_lib

--- a/recipes-core/libc/libc-rs_0.2.21.bb
+++ b/recipes-core/libc/libc-rs_0.2.21.bb
@@ -9,14 +9,15 @@ LIC_FILES_CHKSUM = "\
 inherit rust-bin
 
 SRC_URI = "git://github.com/rust-lang/libc.git;protocol=https"
-SRCREV = "f54b9c90ee68889181472d4d4a5dd9e43d0e5318"
+SRCREV = "05a2d197356ef253dfd985166576619ac9b6947f"
 
 S = "${WORKDIR}/git"
 
 LIB_SRC = "${S}/src/lib.rs"
 
 do_compile () {
-	oe_compile_rust_lib --cfg feature='"cargo-build"'
+	oe_compile_rust_lib --cfg feature='"cargo-build"' --cfg feature='"use_std"'
+
 }
 
 do_install () {

--- a/recipes-core/libc/libc-rs_0.2.5.bb
+++ b/recipes-core/libc/libc-rs_0.2.5.bb
@@ -22,3 +22,5 @@ do_compile () {
 do_install () {
 	oe_install_rust_lib
 }
+
+BBCLASSEXTEND += "native"

--- a/recipes-core/memchr/memchr-rs_0.1.11.bb
+++ b/recipes-core/memchr/memchr-rs_0.1.11.bb
@@ -18,3 +18,5 @@ do_compile () {
 do_install () {
 	oe_install_rust_lib
 }
+
+BBCLASSEXTEND += "native"

--- a/recipes-core/regex/regex-rs.bb
+++ b/recipes-core/regex/regex-rs.bb
@@ -8,3 +8,5 @@ DEPENDS = "\
 require regex.inc
 
 S = "${WORKDIR}/git"
+
+BBCLASSEXTEND += "native"

--- a/recipes-core/regex/regex-syntax-rs.bb
+++ b/recipes-core/regex/regex-syntax-rs.bb
@@ -3,3 +3,5 @@ DESCRIPTION = "A regular expression parser"
 require regex.inc
 
 LIB_SRC = "${S}/regex-syntax/src/lib.rs"
+
+BBCLASSEXTEND += "native"

--- a/recipes-core/time/time-rs_0.1.38.bb
+++ b/recipes-core/time/time-rs_0.1.38.bb
@@ -10,15 +10,12 @@ DEPENDS = "libc-rs"
 inherit rust-bin
 
 SRC_URI = "git://github.com/rust-lang/time.git;protocol=https"
-SRCREV = "32b212b877b836dbfdc97af5674d91672e70ecbd"
+SRCREV = "d265b7cf9f50db74fbd0a01f8bec90ad7d239d48"
 
 S = "${WORKDIR}/git"
 
 do_compile () {
-	rm -rf time_helpers.o libtimehelpers.a
-	${CC} ${S}/src/time_helpers.c -fPIC -c -o time_helpers.o
-	${AR} rcs libtime_helpers.a time_helpers.o
-	oe_compile_rust_lib -L native=$PWD -l static=time_helpers
+	oe_compile_rust_lib
 }
 
 do_install () {


### PR DESCRIPTION
We finally got around to upgrading to rust 1.20/1.21 internally.  We had to make some changes to rust-bin.bbclass to get everything working again.

@meta-rust/maintainers 