### PR TITLE
rust-llvm: remove custom do_compile

### DIFF
--- a/recipes-devtools/rust/rust-llvm.inc
+++ b/recipes-devtools/rust/rust-llvm.inc
@@ -35,10 +35,6 @@ do_compile_prepend_class-target() {
     sed -i 's:/lib\>:/${baselib}:g' ${S}/tools/llvm-config/llvm-config.cpp
 }
 
-do_compile() {
-    oe_runmake
-}
-
 do_install_append_class-target() {
     # Disable checks on the native tools, since these should came from the native recipe
     sed -i -e 's/\(.*APPEND.*_IMPORT_CHECK_FILES_FOR_.*{_IMPORT_PREFIX}\/bin\/.*\)/#\1/' ${D}/usr/share/llvm/cmake/LLVMExports-noconfig.cmake


### PR DESCRIPTION
This works out in recent poky releases because cmake_do_compile ends up
in oe_runmake via base_do_compile, but this changed recently to allow
cmake's generic `cmake --build` feature to call the appropriate
generator instead of always assuming make.

http://git.yoctoproject.org/cgit/cgit.cgi/poky/commit?id=579d17ba5f722edb9fe79682480c4a9508ad0ed4