### PR TITLE
rust: allow configuring panic-strategy

### DIFF
--- a/classes/rust-common.bbclass
+++ b/classes/rust-common.bbclass
@@ -9,6 +9,7 @@ RUST_DEBUG_REMAP = "-Zremap-path-prefix-from=${WORKDIR} -Zremap-path-prefix-to=/
 RUSTFLAGS += "${RUSTLIB} ${RUST_DEBUG_REMAP}"
 RUSTLIB_DEP ?= "libstd-rs"
 RUST_TARGET_PATH = "${STAGING_LIBDIR_NATIVE}/rustlib"
+RUST_PANIC_STRATEGY ?= "unwind"
 
 # Responsible for taking Yocto triples and converting it to Rust triples
 

--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -279,6 +279,7 @@ def rust_gen_target(d, thing, wd):
     tspec['has-rpath'] = True
     tspec['has-elf-tls'] = True
     tspec['position-independent-executables'] = True
+    tspec['panic-strategy'] = d.getVar("RUST_PANIC_STRATEGY")
 
     # Don't use jemalloc as it doesn't work for many targets.
     # https://github.com/rust-lang/rust/pull/37392


### PR DESCRIPTION
This defaults to "unwind" if not set, so this alone has no effect.

Signed-off-by: Tyler Hall <tylerwhall@gmail.com>