### PR TITLE
libstd-rs: Set SONAME for libstd.so

### DIFF
--- a/recipes-devtools/rust/libstd-rs.inc
+++ b/recipes-devtools/rust/libstd-rs.inc
@@ -7,7 +7,7 @@ RUSTLIB_DEP = ""
 inherit cargo
 
 # Needed so cargo can find libbacktrace
-RUSTFLAGS += "-L ${STAGING_LIBDIR}"
+RUSTFLAGS += "-L ${STAGING_LIBDIR} -C link-arg=-Wl,-soname,libstd.so"
 
 S = "${RUSTSRC}/src/libstd"
 


### PR DESCRIPTION
When yocto is searching for lib dependencies it uses SONAMES and RPATHS to find
the right one. When we compile a rust package which dynamically links to rust's
libstd, yocto will not be able to find the matching dependency in shlib and
will complain with a warning. Even worse, if you have compiled go-runtime, the
build will find go-runtime as provider of libstd and will complain that you
missed a RDEPENDS to go-runtime - this is completely wrong obviously.

This patch adds SONAME to rust's stdlib. In this way yocto will create the
required provider and packages dynamically linking to it will be able to find
libstd-rs as a provider of stdlib.

Signed-off-by: Andrei Gherzan <andrei@resin.io>