### PR TITLE
rust-cross: Add arm std-snapshot

### DIFF
--- a/recipes-devtools/rust/files/rust-1.24.1/fix-crate-ver-check.patch
+++ b/recipes-devtools/rust/files/rust-1.24.1/fix-crate-ver-check.patch
@@ -1,0 +1,11 @@
+--- a/src/librustc_metadata/locator.rs	2018-03-14 10:50:49.537437539 +0900
++++ b/src/librustc_metadata/locator.rs	2018-03-14 11:10:14.041437539 +0900
+@@ -673,7 +673,7 @@
+     fn crate_matches(&mut self, metadata: &MetadataBlob, libpath: &Path) -> Option<Svh> {
+         let rustc_version = rustc_version();
+         let found_version = metadata.get_rustc_version();
+-        if found_version != rustc_version {
++        if !&found_version.starts_with(&rustc_version) {
+             info!("Rejecting via version: expected {} got {}",
+                   rustc_version,
+                   found_version);

--- a/recipes-devtools/rust/rust-cross.inc
+++ b/recipes-devtools/rust/rust-cross.inc
@@ -41,6 +41,10 @@ do_compile () {
 do_install () {
 	mkdir -p ${D}${prefix}/${base_libdir_native}/rustlib
 	cp ${WORKDIR}/targets/${TARGET_SYS}.json ${D}${prefix}/${base_libdir_native}/rustlib
+	if [ -n "${RUST_STD_SNAPSHOT_TARGET}" ]; then
+		cp -r ${WORKDIR}/rust-snapshot/lib/rustlib/${RUST_TARGET_SYS} ${D}${prefix}/${base_libdir_native}/rustlib
+		cp    ${WORKDIR}/rust-snapshot/lib/rustlib/manifest-rust-std-${RUST_TARGET_SYS} ${D}${prefix}/${base_libdir_native}/rustlib
+	fi
 }
 
 rust_cross_sysroot_preprocess() {

--- a/recipes-devtools/rust/rust-cross_1.24.1.bb
+++ b/recipes-devtools/rust/rust-cross_1.24.1.bb
@@ -2,3 +2,12 @@ require rust-cross.inc
 require rust-source-${PV}.inc
 require rust-snapshot-${PV}.inc
 
+RUST_STD_SNAPSHOT_TARGET = "rust-std-${RS_VERSION}-${RUST_TARGET_SYS}"
+
+SRC_URI += " \
+	https://static.rust-lang.org/dist/${RUST_STD_SNAPSHOT_TARGET}.tar.gz;name=rust-std-snapshot-target;subdir=rust-snapshot-components \
+"
+
+#arm-unknown-linux-gnueabihf hashes
+SRC_URI[rust-std-snapshot-target.md5sum] = "855bf997716027017c4a5b19a59d17be"
+SRC_URI[rust-std-snapshot-target.sha256sum] = "61d5654881cacf16d0d40fe0fd9cf0f464acc049643e0458666543928addae1e"

--- a/recipes-devtools/rust/rust-snapshot-1.24.1.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.24.1.inc
@@ -4,7 +4,7 @@
 ## snapshot info is taken from rust/src/stage0.txt
 ## TODO: find a way to add additional SRC_URIs based on the contents of an
 ##       earlier SRC_URI.
-RS_VERSION = "1.23.0"
+RS_VERSION = "${PV}"
 
 RUST_STD_SNAPSHOT = "rust-std-${RS_VERSION}-${RUST_BUILD_SYS}"
 RUSTC_SNAPSHOT = "rustc-${RS_VERSION}-${RUST_BUILD_SYS}"
@@ -18,9 +18,9 @@ SRC_URI += " \
 	"
 
 # These are x86_64-unknown-linux-gnu hashes, how can we add more?
-SRC_URI[rustc-snapshot.md5sum] = "068fc6566772c4ce165cc547151f514c"
-SRC_URI[rustc-snapshot.sha256sum] = "27b124fd0d94c082978ff81e45f7b7c37e91d64714587829bf828d64d76524ee"
-SRC_URI[rust-std-snapshot.md5sum] = "f9f89caf41e3f9c092118272ceb5bf6b"
-SRC_URI[rust-std-snapshot.sha256sum] = "83c7351bdc4326caf785c208cff86682825dad4a89ccee705fa05f55ce7bd25b"
+SRC_URI[rustc-snapshot.md5sum] = "218f955f0b3ba90b97845619609828c0"
+SRC_URI[rustc-snapshot.sha256sum] = "61f4853ba83fbe574663973499c3f32009eeccc2f1c83e10c3eb78549aebdfdb"
+SRC_URI[rust-std-snapshot.md5sum] = "ad8b5a2e844eaa48760d53278de20da6"
+SRC_URI[rust-std-snapshot.sha256sum] = "bf421f0f3af569b89dcb8f6b1508bb39be9d5c29bd47282fd9630709c65b71f1"
 SRC_URI[cargo-snapshot.md5sum] = "830041cfc8627d3f7187954993449cf9"
 SRC_URI[cargo-snapshot.sha256sum] = "ff8a454104aba20426ea898ed7515ec5da7de07d11733cdda17462455beb76e8"

--- a/recipes-devtools/rust/rust-source-1.24.1.inc
+++ b/recipes-devtools/rust/rust-source-1.24.1.inc
@@ -2,6 +2,7 @@
 
 SRC_URI += " \
 	https://static.rust-lang.org/dist/rustc-${PV}-src.tar.gz;name=rust \
+	file://rust-${PV}/fix-crate-ver-check.patch;patchdir=${WORKDIR}/rustc-${PV}-src \
 "
 
 SRC_URI[md5sum] = "50639bf359e658fcd713787d5898628d"


### PR DESCRIPTION
For cross-compiler build, I fixed the recipe to

1. prepare std files for cross-target
2. patch the crate ver. check

----

Even with `rust-cross-arm`, **it fails cross-compile because it cannot find build-target std files**
(that is, `/usr/lib/rustlib/${RUST_TARGET_SYS}/**/*` and `/usr/lib/rustlib/manifest-rust-std-${RUST_TARGET_SYS}`).

```
|  0:10.05 checking rustc version... 1.24.1
|  0:10.07 checking cargo version... 0.25.0
|  0:10.24 checking rust target... armv7-unknown-linux-gnueabihf
|  0:10.82 DEBUG: Executing: `********/build/tmp/sysroots/x86_64-linux/usr/bin/rustc --crate-type staticlib --target=armv7-unknown-linux-gnueabihf -o /tmp/conftesttPaMUF.rlib /tmp/conftestoyYUfA.rs`
|  0:10.82 DEBUG: The command returned non-zero exit status 101.
|  0:10.82 DEBUG: Its error output was:
|  0:10.82 DEBUG: | error[E0463]: can't find crate for `std`
|  0:10.82 DEBUG: |   |
|  0:10.82 DEBUG: |   = note: the `armv7-unknown-linux-gnueabihf` target may not be installed
|  0:10.82 DEBUG: |
|  0:10.82 DEBUG: | error: aborting due to previous error
|  0:10.82 DEBUG: |
|  0:10.82 ERROR: Cannot compile for arm-poky-linux-gnueabi with ********/build/tmp/sysroots/x86_64-linux/usr/bin/rustc
|  0:10.82 The target may be unsupported, or you may not have
|  0:10.82 a rust std library for that target installed. Try:
|  0:10.82
|  0:10.82 rustup target add armv7-unknown-linux-gnueabihf
|  0:10.82
|  0:10.85 *** Fix above errors and then restart with\
|  0:10.85                "make -f client.mk build"
|  0:10.85 client.mk:145: recipe for target 'configure' failed
|  0:10.85 make: *** [configure] Error 1
| WARNING: exit code 2 from a shell command.
| ERROR: Function failed: do_configure (log file is located at ********/build/tmp/work/cortexa7hf-vfp-neon-poky-linux-gnueabi/firefox/60.0b3-r0/temp/log.do_configure.17400)
```

As the error avobe saying, we probably should do `rustup target add` I think,
however, there's no `rustup` command built by `meta-rust` can be found.

----

So, instead of calling `rustup`,
**(1) prepared std files for cross-target in the `rust-cross` recipe,**
the same as for host in `rust-snapshot`.

But, so `rust-snapshot` recipe does,
it also have *an issue in source-archive hash assignment for multiple targets*
(Now I set for `arm-unknown-linux-gnueabihf`; And it will raise a hash error for other cross-targets).

-----

Besides, it claims the crates in the target std files are bad in their compiler ver.

But, for std files ver. `rustc 1.24.1 (d3ae9a9e0 2018-02-27)`,
`meta-rust`-built rustc ver. `rustc 1.24.1` should be considered different?

So, **(2) patched the crate ver. check to do partial match.**

```
|  0:09.66 force-cargo-library-build
|  0:09.69 libfreetype.a.desc
|  0:09.94 libxpt.a
|  0:10.04 libxpt.a.desc
|  0:10.06    Compiling mp4parse_fallible v0.0.1
|  0:10.16 error[E0514]: found crate `std` compiled by an incompatible version of rustc
|  0:10.16   |
|  0:10.16   = help: please recompile that crate using this compiler (rustc 1.24.1)
|  0:10.16   = note: the following crate versions were found:
|  0:10.16           crate `std` compiled by rustc 1.24.1 (d3ae9a9e0 2018-02-27): ********/build/tmp/sysroots/x86_64-linux/usr/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libstd_unicode-58e7a51af24928de.rlib
|  0:10.16           crate `std` compiled by rustc 1.24.1 (d3ae9a9e0 2018-02-27): ********/build/tmp/sysroots/x86_64-linux/usr/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libstd-6bb22b30207722f2.rlib
|  0:10.16           crate `std` compiled by rustc 1.24.1 (d3ae9a9e0 2018-02-27): ********/build/tmp/sysroots/x86_64-linux/usr/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libstd-6bb22b30207722f2.so
|  0:10.16
|  0:10.16 error: aborting due to previous error
|  0:10.16
|  0:10.21 error: Could not compile `mp4parse_fallible`.
|  0:10.21
|  0:10.21 To learn more, run the command again with --verbose.
|  0:10.21 ********/build/tmp/work/cortexa7hf-vfp-neon-poky-linux-gnueabi/firefox/git-r0/git/config/rules.mk:971: recipe for target 'force-cargo-library-build' failed
|  0:10.21 make[4]: *** [force-cargo-library-build] Error 101
|  0:10.21 ********/build/tmp/work/cortexa7hf-vfp-neon-poky-linux-gnueabi/firefox/git-r0/git/config/recurse.mk:73: recipe for target 'toolkit/library/rust/target' failed
|  0:10.21 make[3]: *** [toolkit/library/rust/target] Error 2
```

----

(Actually, I checked this on Yocto 2.0, Jethro,
as https://github.com/KSR-Yasuda/meta-rust/tree/jethro-14.0.1_rust_1.24.1 .
This request is cherry-pick from the branch.)
