### PR TITLE
layer.conf: Define LAYERSERIES_COMPAT to fix build warning

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,6 +9,7 @@ BBFILE_PATTERN_rust-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_rust-layer = "7"
 
 LAYERDEPENDS_rust-layer = "core openembedded-layer"
+LAYERSERIES_COMPAT_rust-layer = "sumo"
 
 # Override security flags
 require conf/distro/include/rust_security_flags.inc


### PR DESCRIPTION
Signed-off-by: Andrei Gherzan <andrei@resin.io>