### PR TITLE
rand-rs: switch to a valid 0.3.14 commit id

### DIFF
--- a/recipes-core/rand/rand-rs_0.3.14.bb
+++ b/recipes-core/rand/rand-rs_0.3.14.bb
@@ -10,7 +10,7 @@ DEPENDS = "libc-rs"
 inherit rust-bin
 
 SRC_URI = "git://github.com/rust-lang/rand.git;protocol=https"
-SRCREV = "f872fda5fb8fb899a837ee9eee0332076a8f5300"
+SRCREV = "9d1c297ee98a1657f112b8ad653b81702864b357"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
I found that rand-rs would fail to fetch with this error:
   ERROR: rand-rs-0.3.14-r0 do_fetch: Fetcher failure: Unable to find
revision f872fda5fb8fb899a837ee9eee0332076a8f5300 in branch master even
from upstream

Looking at the git repo, the old commit is present but orphaned.
The new commit has the same release tag:
   9d1c297ee9 (tag: 0.3.14) Bump to 0.3.14
and git diff OLD NEW shows that nothing changed.

Signed-off-by: Randy MacLeod <Randy.MacLeod@windriver.com>