### PR TITLE
Various fixes, Clang, TCLIBC, DEBUG_BUILD, rocko 

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -23,11 +23,13 @@ B = "${S}"
 export RUST_BACKTRACE = "1"
 
 RUSTFLAGS ??= ""
-CARGO_BUILD_FLAGS = "-v --target ${HOST_SYS} --release"
+BUILD_MODE = "${@['--release', ''][d.getVar('DEBUG_BUILD') == '1']}"
+CARGO_BUILD_FLAGS = "-v --target ${HOST_SYS} ${BUILD_MODE}"
 
 # This is based on the content of CARGO_BUILD_FLAGS and generally will need to
 # change if CARGO_BUILD_FLAGS changes.
-CARGO_TARGET_SUBDIR="${HOST_SYS}/release"
+BUILD_DIR = "${@['release', 'debug'][d.getVar('DEBUG_BUILD') == '1']}"
+CARGO_TARGET_SUBDIR="${HOST_SYS}/${BUILD_DIR}"
 oe_cargo_build () {
 	export RUSTFLAGS="${RUSTFLAGS}"
 	export RUST_TARGET_PATH="${RUST_TARGET_PATH}"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_PATTERN_rust-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_rust-layer = "7"
 
 LAYERDEPENDS_rust-layer = "core openembedded-layer"
-LAYERSERIES_COMPAT_rust-layer = "sumo"
+LAYERSERIES_COMPAT_rust-layer = "rocko sumo"
 
 # Override security flags
 require conf/distro/include/rust_security_flags.inc

--- a/recipes-devtools/cargo/cargo-0.27.0.inc
+++ b/recipes-devtools/cargo/cargo-0.27.0.inc
@@ -1,10 +1,11 @@
 CARGO_SNAPSHOT = "cargo-0.26.0-${RUST_BUILD_SYS}"
 
-SRC_URI[cargo-snapshot.md5sum] = "b0de62d86f0ba71078471d09916873c6"
-SRC_URI[cargo-snapshot.sha256sum] = "9ba227f2364f618dc9415dacf3a5dce17458e1cb9f6d4fe860416cb68db894e4"
+# TODO: Add hashes for other architecture toolchains as well. Make a script?
+SRC_URI[cargo-snapshot-x86_64.md5sum] = "b0de62d86f0ba71078471d09916873c6"
+SRC_URI[cargo-snapshot-x86_64.sha256sum] = "9ba227f2364f618dc9415dacf3a5dce17458e1cb9f6d4fe860416cb68db894e4"
 
 SRC_URI += "\
-    https://static.rust-lang.org/dist/${CARGO_SNAPSHOT}.tar.gz;name=cargo-snapshot \
+    https://static.rust-lang.org/dist/${CARGO_SNAPSHOT}.tar.gz;name=cargo-snapshot-${BUILD_ARCH} \
 "
 
 # When building cargo-native we don't have a built cargo to use so we must use

--- a/recipes-devtools/rust/rust-llvm.inc
+++ b/recipes-devtools/rust/rust-llvm.inc
@@ -21,6 +21,7 @@ EXTRA_OECMAKE = " \
     -DLLVM_BUILD_TESTS=OFF \
     -DLLVM_INCLUDE_TESTS=OFF \
     -DLLVM_TARGET_ARCH=${TARGET_ARCH} \
+    -DCMAKE_INSTALL_PREFIX:PATH=${libdir}/llvm-rust \
 "
 
 # The debug symbols are huge here (>2GB) so suppress them since they

--- a/recipes-devtools/rust/rust-snapshot-1.26.2.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.26.2.inc
@@ -6,21 +6,21 @@
 ##       earlier SRC_URI.
 RS_VERSION = "1.25.0"
 
-RUST_STD_SNAPSHOT = "rust-std-${RS_VERSION}-${RUST_BUILD_SYS}"
-RUSTC_SNAPSHOT = "rustc-${RS_VERSION}-${RUST_BUILD_SYS}"
+RUST_STD_SNAPSHOT = "rust-std-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
+RUSTC_SNAPSHOT = "rustc-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
 CARGO_VERSION = "0.26.0"
-CARGO_SNAPSHOT = "cargo-${CARGO_VERSION}-${RUST_BUILD_SYS}"
+CARGO_SNAPSHOT = "cargo-${CARGO_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
 
 SRC_URI += " \
-	https://static.rust-lang.org/dist/${RUST_STD_SNAPSHOT}.tar.gz;name=rust-std-snapshot;subdir=rust-snapshot-components \
-	https://static.rust-lang.org/dist/${RUSTC_SNAPSHOT}.tar.gz;name=rustc-snapshot;subdir=rust-snapshot-components \
-	https://static.rust-lang.org/dist/${CARGO_SNAPSHOT}.tar.gz;name=cargo-snapshot;subdir=rust-snapshot-components \
+	https://static.rust-lang.org/dist/${RUST_STD_SNAPSHOT}.tar.gz;name=rust-std-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
+	https://static.rust-lang.org/dist/${RUSTC_SNAPSHOT}.tar.gz;name=rustc-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
+	https://static.rust-lang.org/dist/${CARGO_SNAPSHOT}.tar.gz;name=cargo-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
 	"
 
-# These are x86_64-unknown-linux-gnu hashes, how can we add more?
-SRC_URI[rustc-snapshot.md5sum] = "6e9c8ae2946cf6626ad6511c7a1d6c2a"
-SRC_URI[rustc-snapshot.sha256sum] = "f8f4ae2f4b76416bfa90758267df4280dd078235dfba92dac0431595493443be"
-SRC_URI[rust-std-snapshot.md5sum] = "37e9f9193413caba47134af3306328c5"
-SRC_URI[rust-std-snapshot.sha256sum] = "a3258308e3a9fe364d63b5d782efb285ab410bdfc01d168c119122ddbc9a02e2"
-SRC_URI[cargo-snapshot.md5sum] = "b0de62d86f0ba71078471d09916873c6"
-SRC_URI[cargo-snapshot.sha256sum] = "9ba227f2364f618dc9415dacf3a5dce17458e1cb9f6d4fe860416cb68db894e4"
+# TODO: Add hashes for other architecture toolchains as well. Make a script?
+SRC_URI[rustc-snapshot-x86_64.md5sum] = "6e9c8ae2946cf6626ad6511c7a1d6c2a"
+SRC_URI[rustc-snapshot-x86_64.sha256sum] = "f8f4ae2f4b76416bfa90758267df4280dd078235dfba92dac0431595493443be"
+SRC_URI[rust-std-snapshot-x86_64.md5sum] = "37e9f9193413caba47134af3306328c5"
+SRC_URI[rust-std-snapshot-x86_64.sha256sum] = "a3258308e3a9fe364d63b5d782efb285ab410bdfc01d168c119122ddbc9a02e2"
+SRC_URI[cargo-snapshot-x86_64.md5sum] = "b0de62d86f0ba71078471d09916873c6"
+SRC_URI[cargo-snapshot-x86_64.sha256sum] = "9ba227f2364f618dc9415dacf3a5dce17458e1cb9f6d4fe860416cb68db894e4"

--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -339,7 +339,7 @@ python do_configure() {
     target_section = "target.{}".format(d.getVar('TARGET_SYS', True))
     config.add_section(target_section)
 
-    llvm_config = d.expand("${STAGING_DIR_NATIVE}${bindir_native}/llvm-config")
+    llvm_config = d.expand("${STAGING_DIR_NATIVE}${libdir_native}/llvm-rust/bin/llvm-config")
     config.set(target_section, "llvm-config", e(llvm_config))
 
     config.set(target_section, "cxx", e(d.expand("${RUST_TARGET_CXX}")))

--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -13,6 +13,9 @@ export RUST_TARGET_PATH="${WORKDIR}/targets/"
 
 export FORCE_CRATE_HASH="${BB_TASKHASH}"
 
+# We can't use RUST_BUILD_SYS here because that may be "musl" if
+# TCLIBC="musl". Snapshots are always -unknown-linux-gnu
+SNAPSHOT_BUILD_SYS = "${BUILD_ARCH}-unknown-linux-gnu"
 setup_cargo_environment () {
     # The first step is to build bootstrap and some early stage tools,
     # these are build for the same target as the snapshot, e.g.
@@ -20,8 +23,8 @@ setup_cargo_environment () {
     # Later stages are build for the native target (i.e. target.x86_64-linux)
     cargo_common_do_configure
 
-    echo "[target.${RUST_BUILD_SYS}]" >> ${CARGO_HOME}/config
-    echo "linker = '${RUST_TARGET_CCLD}'" >> ${CARGO_HOME}/config
+    printf '[target.%s]\n' "${SNAPSHOT_BUILD_SYS}" >> ${CARGO_HOME}/config
+    printf "linker = '%s'\n" "${RUST_BUILD_CCLD}" >> ${CARGO_HOME}/config
 }
 
 # Right now this is focused on arm-specific tune features.

--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -142,39 +142,39 @@ TARGET_C_INT_WIDTH[arm] = "32"
 MAX_ATOMIC_WIDTH[arm] = "64"
 FEATURES[arm] = "+v6,+vfp2"
 
-## aarch64-unknown-linux-gnu
+## aarch64-unknown-linux-{gnu, musl}
 DATA_LAYOUT[aarch64] = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
-LLVM_TARGET[aarch64] = "aarch64-unknown-linux-gnu"
+LLVM_TARGET[aarch64] = "${RUST_TARGET_SYS}"
 TARGET_ENDIAN[aarch64] = "little"
 TARGET_POINTER_WIDTH[aarch64] = "64"
 TARGET_C_INT_WIDTH[aarch64] = "32"
 MAX_ATOMIC_WIDTH[aarch64] = "128"
 
-## x86_64-unknown-linux-gnu
+## x86_64-unknown-linux-{gnu, musl}
 DATA_LAYOUT[x86_64] = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
-LLVM_TARGET[x86_64] = "x86_64-unknown-linux-gnu"
+LLVM_TARGET[x86_64] = "${RUST_TARGET_SYS}"
 TARGET_ENDIAN[x86_64] = "little"
 TARGET_POINTER_WIDTH[x86_64] = "64"
 TARGET_C_INT_WIDTH[x86_64] = "32"
 MAX_ATOMIC_WIDTH[x86_64] = "64"
 
-## i686-unknown-linux-gnu
+## i686-unknown-linux-{gnu, musl}
 DATA_LAYOUT[i686] = "e-m:e-p:32:32-f64:32:64-f80:32-n8:16:32-S128"
-LLVM_TARGET[i686] = "i686-unknown-linux-gnu"
+LLVM_TARGET[i686] = "${RUST_TARGET_SYS}"
 TARGET_ENDIAN[i686] = "little"
 TARGET_POINTER_WIDTH[i686] = "32"
 TARGET_C_INT_WIDTH[i686] = "32"
 MAX_ATOMIC_WIDTH[i686] = "64"
 
-## XXX: a bit of a hack so qemux86 builds, clone of i686-unknown-linux-gnu above
+## XXX: a bit of a hack so qemux86 builds, clone of i686-unknown-linux-{gnu, musl} above
 DATA_LAYOUT[i586] = "e-m:e-p:32:32-f64:32:64-f80:32-n8:16:32-S128"
-LLVM_TARGET[i586] = "i586-unknown-linux-gnu"
+LLVM_TARGET[i586] = "${RUST_TARGET_SYS}"
 TARGET_ENDIAN[i586] = "little"
 TARGET_POINTER_WIDTH[i586] = "32"
 TARGET_C_INT_WIDTH[i586] = "32"
 MAX_ATOMIC_WIDTH[i586] = "64"
 
-## mips-unknown-linux-gnu
+## mips-unknown-linux-{gnu, musl}
 DATA_LAYOUT[mips] = "E-m:m-p:32:32-i8:8:32-i16:16:32-i64:64-n32-S64"
 LLVM_TARGET[mips] = "${RUST_TARGET_SYS}"
 TARGET_ENDIAN[mips] = "big"
@@ -182,7 +182,7 @@ TARGET_POINTER_WIDTH[mips] = "32"
 TARGET_C_INT_WIDTH[mips] = "32"
 MAX_ATOMIC_WIDTH[mips] = "32"
 
-## mipsel-unknown-linux-gnu
+## mipsel-unknown-linux-{gnu, musl}
 DATA_LAYOUT[mipsel] = "e-m:m-p:32:32-i8:8:32-i16:16:32-i64:64-n32-S64"
 LLVM_TARGET[mipsel] = "${RUST_TARGET_SYS}"
 TARGET_ENDIAN[mipsel] = "little"
@@ -267,7 +267,10 @@ def rust_gen_target(d, thing, wd):
     tspec['target-endian'] = d.getVarFlag('TARGET_ENDIAN', arch)
     tspec['arch'] = arch_to_rust_target_arch(arch)
     tspec['os'] = "linux"
-    tspec['env'] = "gnu"
+    if "musl" in tspec['llvm-target']:
+        tspec['env'] = "musl"
+    else:
+        tspec['env'] = "gnu"
     tspec['vendor'] = "unknown"
     tspec['target-family'] = "unix"
     tspec['linker'] = "{}{}gcc".format(d.getVar('CCACHE'), prefix)

--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -147,7 +147,7 @@ DATA_LAYOUT[aarch64] = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
 LLVM_TARGET[aarch64] = "aarch64-unknown-linux-gnu"
 TARGET_ENDIAN[aarch64] = "little"
 TARGET_POINTER_WIDTH[aarch64] = "64"
-TARGET_C_INT_WIDTH[aarch64] = "64"
+TARGET_C_INT_WIDTH[aarch64] = "32"
 MAX_ATOMIC_WIDTH[aarch64] = "128"
 
 ## x86_64-unknown-linux-gnu
@@ -155,7 +155,7 @@ DATA_LAYOUT[x86_64] = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 LLVM_TARGET[x86_64] = "x86_64-unknown-linux-gnu"
 TARGET_ENDIAN[x86_64] = "little"
 TARGET_POINTER_WIDTH[x86_64] = "64"
-TARGET_C_INT_WIDTH[x86_64] = "64"
+TARGET_C_INT_WIDTH[x86_64] = "32"
 MAX_ATOMIC_WIDTH[x86_64] = "64"
 
 ## i686-unknown-linux-gnu


### PR DESCRIPTION
This is a few smaller fixes and tweaks I've come up with.

First is if you set DEBUG_BUILD="1" in a cargo recipe, cargo will build without --release. This mimics DEBUG_BUILD pretty well (it sets "-O0 -g" etc in normal builds). set DEBUG_BUILD_pn-whateverpackage = "1" in conf/local.conf for much shorter compile times.

Second is a change which installs rust-llvm into a subdir instead of ${prefix} as usual. It makes it possible to use meta-rust and meta-clang together. It should also fix #173.

Third adds the possibility to use TCLIBC="musl". I.e. replace glibc with musl. It seems to work and rust applications are dynamically linked to musl. Can be good to decrease the size of firmwares. It is even possible to use meta-clang, meta-rust and musl together.

Forth is adding rocko as a compatible layer. The master branch still work fine for rocko and I don't think we should artificially limit what branch you can use master on.

Fifth is target-c-int-width was incorrect on a couple of targets.

Sixth is env needs to be set to "musl" and llvm-target to "X-musl", but only for for TARGET and only when not building -native packages.