### PR TITLE
libstd-rs: support debug builds

### DIFF
--- a/recipes-devtools/rust/libstd-rs.inc
+++ b/recipes-devtools/rust/libstd-rs.inc
@@ -23,6 +23,6 @@ do_install () {
     # With the incremental build support added in 1.24, the libstd deps directory also includes dependency
     # files that get installed. Those are really only needed to incrementally rebuild the libstd library
     # itself and don't need to be installed.
-    rm ${B}/${TARGET_SYS}/release/deps/*.d
-    cp ${B}/${TARGET_SYS}/release/deps/* ${D}${rustlibdir}
+    rm ${B}/${TARGET_SYS}/${BUILD_DIR}/deps/*.d
+    cp ${B}/${TARGET_SYS}/${BUILD_DIR}/deps/* ${D}${rustlibdir}
 }


### PR DESCRIPTION
When DEBUG_BUILD is set in conf/local.conf, libstd-rs fails to build