### PR TITLE
libstd-rs: use a separate variable for --features

### DIFF
--- a/recipes-devtools/rust/libstd-rs.inc
+++ b/recipes-devtools/rust/libstd-rs.inc
@@ -11,6 +11,8 @@ RUSTFLAGS += "-L ${STAGING_LIBDIR} -C link-arg=-Wl,-soname,libstd.so"
 
 S = "${RUSTSRC}/src/libstd"
 
+CARGO_BUILD_FLAGS += "--features '${CARGO_FEATURES}'"
+
 do_compile_prepend () {
     export CARGO_TARGET_DIR="${B}"
     # For Rust 1.13.0 and newer

--- a/recipes-devtools/rust/libstd-rs_1.26.2.bb
+++ b/recipes-devtools/rust/libstd-rs_1.26.2.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://../../COPYRIGHT;md5=99c369ad81a36cd5b27f6c6968d01055"
 
 # Don't use jemalloc as it doesn't work for many targets.
 # https://github.com/rust-lang/rust/pull/37392
-CARGO_BUILD_FLAGS += "--features 'panic-unwind'"
+CARGO_FEATURES ?= "panic-unwind"
 
 # These are taken from src/libstd/Cargo.toml via cargo-bitbake
 SRC_URI += " \


### PR DESCRIPTION
This will allow features to be easily modified through a bbappend file
in another layer.

The last local commit we had to meta-rust was for this purpose.  This commit would allow us to replace our local commit with a bbappend instead.