### PR TITLE
rust-common: fix remap-path-prefix for 1.26

### DIFF
--- a/classes/rust-common.bbclass
+++ b/classes/rust-common.bbclass
@@ -5,7 +5,7 @@ FILES_${PN}-dev += "${rustlibdir}/*.rlib"
 FILES_${PN}-dbg += "${rustlibdir}/.debug"
 
 RUSTLIB = "-L ${STAGING_LIBDIR}/rust"
-RUST_DEBUG_REMAP = "--remap-path-prefix=from=${WORKDIR} --remap-path-prefix=to=/usr/src/debug/${PN}/${EXTENDPE}${PV}-${PR}"
+RUST_DEBUG_REMAP = "--remap-path-prefix=${WORKDIR}=/usr/src/debug/${PN}/${EXTENDPE}${PV}-${PR}"
 RUSTFLAGS += "${RUSTLIB} ${RUST_DEBUG_REMAP}"
 RUSTLIB_DEP ?= "libstd-rs"
 RUST_TARGET_PATH = "${STAGING_LIBDIR_NATIVE}/rustlib"


### PR DESCRIPTION
Before the flag was stabilized, it required two arguments of the form
"from=<from_path>" and "to=<to_path>" respectively. The stabilized
version uses one argument of the form "<from_path>=<to_path>".

Unfortunately the old format is still parsed successfully, but results
in attempting to replace the literal paths "from" and "to".

https://github.com/rust-lang/rust/issues/41555#issuecomment-320951103