### PR TITLE
Fix building llvm (inspirations from meta-clang)

### DIFF
--- a/recipes-devtools/rust/rust-llvm.inc
+++ b/recipes-devtools/rust/rust-llvm.inc
@@ -14,6 +14,9 @@ DEPENDS += "ninja-native rust-llvm-native"
 ARM_INSTRUCTION_SET_armv5 = "arm"
 ARM_INSTRUCTION_SET_armv4t = "arm"
 
+LLVM_RELEASE = "6.0"
+LLVM_DIR = "llvm${LLVM_RELEASE}"
+
 EXTRA_OECMAKE = " \
     -DCMAKE_BUILD_TYPE=Release \
     -DLLVM_TARGETS_TO_BUILD='X86;ARM;AArch64;PowerPC;Mips' \
@@ -40,21 +43,6 @@ EXTRA_OECMAKE_append_class-target = "\
 # The debug symbols are huge here (>2GB) so suppress them since they
 # provide almost no value. If you really need them then override this
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
-
-do_compile_prepend_class-target() {
-    # Fix paths in llvm-config
-    sed -i "s|sys::path::parent_path(CurrentPath))\.str()|sys::path::parent_path(sys::path::parent_path(CurrentPath))).str()|g" ${S}/tools/llvm-config/llvm-config.cpp
-
-    # Fix the hardcoded libdir in llvm-config
-    sed -i 's:/lib\>:/${baselib}:g' ${S}/tools/llvm-config/llvm-config.cpp
-}
-do_compile_class-native() {
-    ninja -v ${PARALLEL_MAKE} llvm-config llvm-tblgen
-}
-do_install_class-native() {
-    install -D -m 0755 ${B}/bin/llvm-tblgen ${D}${libdir}/llvm-rust/bin/llvm-tblgen
-    install -D -m 0755 ${B}/bin/llvm-config ${D}${libdir}/llvm-rust/bin/llvm-config
-}
 
 do_install_append_class-target() {
     # Disable checks on the native tools, since these should came from the native recipe

--- a/recipes-devtools/rust/rust-llvm.inc
+++ b/recipes-devtools/rust/rust-llvm.inc
@@ -1,11 +1,18 @@
 SUMMARY = "LLVM compiler framework (packaged with rust)"
 LICENSE = "NCSA"
 
+SRC_URI += "file://0002-llvm-allow-env-override-of-exe-path.patch"
+
 S = "${RUSTSRC}/src/llvm"
 
 LIC_FILES_CHKSUM = "file://LICENSE.TXT;md5=4c0bc17c954e99fd547528d938832bfa"
 
 inherit cmake pythonnative
+
+DEPENDS += "ninja-native rust-llvm-native"
+
+ARM_INSTRUCTION_SET_armv5 = "arm"
+ARM_INSTRUCTION_SET_armv4t = "arm"
 
 EXTRA_OECMAKE = " \
     -DCMAKE_BUILD_TYPE=Release \
@@ -13,15 +20,21 @@ EXTRA_OECMAKE = " \
     -DLLVM_BUILD_DOCS=OFF \
     -DLLVM_ENABLE_TERMINFO=OFF \
     -DLLVM_ENABLE_ZLIB=OFF \
+    -DLLVM_ENABLE_LIBXML2=OFF \
     -DLLVM_ENABLE_FFI=OFF \
     -DLLVM_INSTALL_UTILS=ON \
-    -DLLVM_BUILD_TOOLS=ON \
     -DLLVM_BUILD_EXAMPLES=OFF \
     -DLLVM_INCLUDE_EXAMPLES=OFF \
     -DLLVM_BUILD_TESTS=OFF \
     -DLLVM_INCLUDE_TESTS=OFF \
     -DLLVM_TARGET_ARCH=${TARGET_ARCH} \
     -DCMAKE_INSTALL_PREFIX:PATH=${libdir}/llvm-rust \
+"
+EXTRA_OECMAKE_append_class-target = "\
+    -DCMAKE_CROSSCOMPILING:BOOL=ON \
+    -DLLVM_BUILD_TOOLS=OFF \
+    -DLLVM_TABLEGEN=${STAGING_LIBDIR_NATIVE}/llvm-rust/bin/llvm-tblgen \
+    -DLLVM_CONFIG_PATH=${STAGING_LIBDIR_NATIVE}/llvm-rust/bin/llvm-config \
 "
 
 # The debug symbols are huge here (>2GB) so suppress them since they
@@ -35,32 +48,27 @@ do_compile_prepend_class-target() {
     # Fix the hardcoded libdir in llvm-config
     sed -i 's:/lib\>:/${baselib}:g' ${S}/tools/llvm-config/llvm-config.cpp
 }
+do_compile_class-native() {
+    ninja -v ${PARALLEL_MAKE} llvm-config llvm-tblgen
+}
+do_install_class-native() {
+    install -D -m 0755 ${B}/bin/llvm-tblgen ${D}${libdir}/llvm-rust/bin/llvm-tblgen
+    install -D -m 0755 ${B}/bin/llvm-config ${D}${libdir}/llvm-rust/bin/llvm-config
+}
 
 do_install_append_class-target() {
     # Disable checks on the native tools, since these should came from the native recipe
     sed -i -e 's/\(.*APPEND.*_IMPORT_CHECK_FILES_FOR_.*{_IMPORT_PREFIX}\/bin\/.*\)/#\1/' ${D}/usr/share/llvm/cmake/LLVMExports-noconfig.cmake
 }
 
-SYSROOT_PREPROCESS_FUNCS_append_class-target = " llvm_sysroot_preprocess"
-SYSROOT_PREPROCESS_FUNCS_append_class-native = " llvm_native_sysroot_preprocess"
-
-llvm_sysroot_preprocess() {
-    install -d ${SYSROOT_DESTDIR}${bindir}
-    cp ${B}/NATIVE/bin/llvm-config ${SYSROOT_DESTDIR}/${bindir} || bbfatal "missing llvm-config"
-    cp ${B}/NATIVE/bin/llvm-tblgen ${SYSROOT_DESTDIR}/${bindir} || bbfatal "missing llvm-tblgen"
-}
-
-llvm_native_sysroot_preprocess() {
-    sysroot_stage_dir ${D}${STAGING_DIR_NATIVE}/usr/libexec ${SYSROOT_DESTDIR}${bindir}
-}
-
 PACKAGES =+ "${PN}-bugpointpasses ${PN}-llvmhello ${PN}-liblto"
 
 # Add the extra locations to avoid the complaints about unpackaged files
-FILES_${PN} += "${libdir}/libLLVM*.so"
-FILES_${PN}-dev += "${datadir}/llvm"
-FILES_${PN}-bugpointpasses = "${libdir}/BugpointPasses.so"
-FILES_${PN}-llvmhello = "${libdir}/LLVMHello.so"
-FILES_${PN}-liblto = "${libdir}/libLTO.so"
+FILES_${PN}-bugpointpasses = "${libdir}/llvm-rust/lib/BugpointPasses.so"
+FILES_${PN}-llvmhello = "${libdir}/llvm-rust/lib/LLVMHello.so"
+FILES_${PN}-liblto = "${libdir}/llvm-rust/lib/libLTO.so.*"
+FILES_${PN}-staticdev =+ "${libdir}/llvm-rust/*/*.a"
+FILES_${PN} += "${libdir}/libLLVM*.so.* ${libdir}/llvm-rust/lib/*.so.* ${libdir}/llvm-rust/bin"
+FILES_${PN}-dev += "${datadir}/llvm ${libdir}/llvm-rust/lib/*.so ${libdir}/llvm-rust/include ${libdir}/llvm-rust/share ${libdir}/llvm-rust/lib/cmake"
 
 BBCLASSEXTEND = "native"

--- a/recipes-devtools/rust/rust-llvm/0002-llvm-allow-env-override-of-exe-path.patch
+++ b/recipes-devtools/rust/rust-llvm/0002-llvm-allow-env-override-of-exe-path.patch
@@ -1,0 +1,70 @@
+From aeccf16eaccdd80e4d5ecaa51673ce4b2bac1130 Mon Sep 17 00:00:00 2001
+From: Martin Kelly <mkelly@xevo.com>
+Date: Fri, 19 May 2017 00:22:57 -0700
+Subject: [PATCH 2/2] llvm: allow env override of exe path
+
+When using a native llvm-config from inside a sysroot, we need llvm-config to
+return the libraries, include directories, etc. from inside the sysroot rather
+than from the native sysroot. Thus provide an env override for calling
+llvm-config from a target sysroot.
+
+To let it work in multilib environment, we need to provide a knob to supply
+multilib dirname as well
+
+Upstream-Status: Inappropriate [OE-Specific]
+
+Signed-off-by: Martin Kelly <mkelly@xevo.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ tools/llvm-config/llvm-config.cpp | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+Index: llvm/tools/llvm-config/llvm-config.cpp
+===================================================================
+--- llvm.orig/tools/llvm-config/llvm-config.cpp
++++ llvm/tools/llvm-config/llvm-config.cpp
+@@ -225,6 +225,13 @@ Typical components:\n\
+ 
+ /// \brief Compute the path to the main executable.
+ std::string GetExecutablePath(const char *Argv0) {
++  // Hack for Yocto: we need to override the root path when we are using
++  // llvm-config from within a target sysroot.
++  const char *Sysroot = std::getenv("YOCTO_ALTERNATE_EXE_PATH");
++  if (Sysroot != nullptr) {
++    return Sysroot;
++  }
++
+   // This just needs to be some symbol in the binary; C++ doesn't
+   // allow taking the address of ::main however.
+   void *P = (void *)(intptr_t)GetExecutablePath;
+@@ -306,12 +313,21 @@ int main(int argc, char **argv) {
+   std::string ActivePrefix, ActiveBinDir, ActiveIncludeDir, ActiveLibDir,
+               ActiveCMakeDir;
+   std::string ActiveIncludeOption;
++  // Hack for Yocto: we need to override the multilib path when we are using
++  // llvm-config from within a target sysroot.
++  std::string Multilibdir;
++  if (std::getenv("YOCTO_ALTERNATE_MULTILIB_NAME") != nullptr)
++    Multilibdir = std::getenv("YOCTO_ALTERNATE_MULTILIB_NAME");
++  else
++    Multilibdir = "/lib" LLVM_LIBDIR_SUFFIX;
++
+   if (IsInDevelopmentTree) {
+     ActiveIncludeDir = std::string(LLVM_SRC_ROOT) + "/include";
+     ActivePrefix = CurrentExecPrefix;
+ 
+     // CMake organizes the products differently than a normal prefix style
+     // layout.
++
+     switch (DevelopmentTreeLayout) {
+     case CMakeStyle:
+       ActiveBinDir = ActiveObjRoot + "/bin";
+@@ -336,7 +352,7 @@ int main(int argc, char **argv) {
+     SmallString<256> path(StringRef(LLVM_TOOLS_INSTALL_DIR));
+     sys::fs::make_absolute(ActivePrefix, path);
+     ActiveBinDir = path.str();
+-    ActiveLibDir = ActivePrefix + "/lib" + LLVM_LIBDIR_SUFFIX;
++    ActiveLibDir = ActivePrefix + Multilibdir;
+     ActiveCMakeDir = ActiveLibDir + "/cmake/llvm";
+     ActiveIncludeOption = "-I" + ActiveIncludeDir;
+   }

--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -7,11 +7,15 @@ inherit rust
 inherit cargo_common
 
 DEPENDS += "file-native python-native"
+DEPENDS_append_class-native = " rust-llvm-native"
 
 # We generate local targets, and need to be able to locate them
 export RUST_TARGET_PATH="${WORKDIR}/targets/"
 
 export FORCE_CRATE_HASH="${BB_TASKHASH}"
+
+export YOCTO_ALTERNATE_EXE_PATH = "${STAGING_LIBDIR}/llvm-rust/bin/llvm-config"
+export YOCTO_ALTERNATE_MULTILIB_NAME = "/${BASELIB}"
 
 # We can't use RUST_BUILD_SYS here because that may be "musl" if
 # TCLIBC="musl". Snapshots are always -unknown-linux-gnu
@@ -345,7 +349,7 @@ python do_configure() {
     target_section = "target.{}".format(d.getVar('TARGET_SYS', True))
     config.add_section(target_section)
 
-    llvm_config = d.expand("${STAGING_DIR_NATIVE}${libdir_native}/llvm-rust/bin/llvm-config")
+    llvm_config = d.expand("${YOCTO_ALTERNATE_EXE_PATH}")
     config.set(target_section, "llvm-config", e(llvm_config))
 
     config.set(target_section, "cxx", e(d.expand("${RUST_TARGET_CXX}")))


### PR DESCRIPTION
This make llvm cross build work better and we can compile libstd-rs, target rust still fails with SIGSEGV in rustc but that was failing always