### PR TITLE
Fix TARGET_CXXFLAGS in cargo_common

### DIFF
--- a/classes/cargo_common.bbclass
+++ b/classes/cargo_common.bbclass
@@ -60,7 +60,7 @@ oe_cargo_fix_env () {
 	export TARGET_CC="${RUST_TARGET_CC}"
 	export TARGET_CXX="${RUST_TARGET_CXX}"
 	export TARGET_CFLAGS="${CFLAGS}"
-	export TARGET_CFLAGS="${CXXFLAGS}"
+	export TARGET_CXXFLAGS="${CXXFLAGS}"
 	export TARGET_AR="${AR}"
 	export HOST_CC="${RUST_BUILD_CC}"
 	export HOST_CXX="${RUST_BUILD_CXX}"


### PR DESCRIPTION
`TARGET_CFLAGS` is used twice, copying `CXXFLAGS` into `TARGET_CFLAGS`.

I have a recipe failing to build because some C++-only flags are being appended to `CFLAGS`. It looks like this is the source of the issue. Making the change below solved the issue.