### PR TITLE
libstd don't fail if incremental build files don't exist (sumo)

### DIFF
--- a/recipes-devtools/rust/libstd-rs.inc
+++ b/recipes-devtools/rust/libstd-rs.inc
@@ -23,6 +23,6 @@ do_install () {
     # With the incremental build support added in 1.24, the libstd deps directory also includes dependency
     # files that get installed. Those are really only needed to incrementally rebuild the libstd library
     # itself and don't need to be installed.
-    rm ${B}/${TARGET_SYS}/release/deps/*.d
+    rm -f ${B}/${TARGET_SYS}/release/deps/*.d
     cp ${B}/${TARGET_SYS}/release/deps/* ${D}${rustlibdir}
 }


### PR DESCRIPTION
if ${B}/${TARGET_SYS}/release/deps/*.d is empty the build fails
with the -f flag it ignores if that is empty..

This happens on sumo if `PREFERRED_VERSION_cargo-native = 0.22.%` is set.
due to #220 