### PR TITLE
libstd-rs: Depend on libunwind on musl builds

### DIFF
--- a/recipes-devtools/rust/libstd-rs.inc
+++ b/recipes-devtools/rust/libstd-rs.inc
@@ -6,6 +6,7 @@ LICENSE = "MIT | Apache-2.0"
 RUSTLIB_DEP = ""
 inherit cargo
 
+DEPENDS_append_libc-musl = " libunwind"
 # Needed so cargo can find libbacktrace
 RUSTFLAGS += "-L ${STAGING_LIBDIR} -C link-arg=-Wl,-soname,libstd.so"
 


### PR DESCRIPTION
musl builds need libunwind.a to be in sysroot for libstd-rs to build
unwinding support into it. This also means we need to compile libunwind
with --enable-static in oe-core

Signed-off-by: Khem Raj <raj.khem@gmail.com>