### PR TITLE
Set proxy in cargo if available

### DIFF
--- a/classes/cargo_common.bbclass
+++ b/classes/cargo_common.bbclass
@@ -51,6 +51,20 @@ cargo_common_do_configure () {
 		EOF
 	fi
 
+	if [ -n "${http_proxy}" ]; then
+		cat <<- EOF >> ${CARGO_HOME}/config
+		[http]
+		proxy = "${http_proxy}"
+		EOF
+	fi
+
+	if [ -n "${https_proxy}" ]; then
+		cat <<- EOF >> ${CARGO_HOME}/config
+		[https]
+		proxy = "${https_proxy}"
+		EOF
+	fi
+
 	echo "[target.${HOST_SYS}]" >> ${CARGO_HOME}/config
 	echo "linker = '${RUST_TARGET_CCLD}'" >> ${CARGO_HOME}/config
 	if [ "${HOST_SYS}" != "${BUILD_SYS}" ]; then


### PR DESCRIPTION
This is needed for cargo to use proxies set by bitbake. It is important
for devtooled builds which does not use vendored sources.