### PR TITLE
rust: don't configure thumb if not in TUNE_FEATURES

### DIFF
--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -78,10 +78,11 @@ def llvm_features_from_tune(d):
     if 'dsp' in feat:
         f.append("+dsp")
 
-    if d.getVar('ARM_THUMB_OPT') is "thumb":
-        if not feat.isdisjoint(v7):
-            f.append("+thumb2")
-        f.append("+thumb-mode")
+    if 'thumb' in feat:
+        if d.getVar('ARM_THUMB_OPT') is "thumb":
+            if not feat.isdisjoint(v7):
+                f.append("+thumb2")
+            f.append("+thumb-mode")
 
     if 'cortexa5' in feat:
         f.append("+a5")


### PR DESCRIPTION
ARM_INSTRUCTION_SET, and therefore ARM_THUMB_OPT also, expect to only be
used in conjunction with the thumb TUNE_FEATURES. So thumb-mode should only
be added if thumb is in TUNE_FEATURES and ARM_THUMB_OPT is thumb.

The commit https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/meta/conf/machine/include/arm/arch-armv7a.inc?id=3e7d26e31a724009e69788460737e07163a14051
caused armv7a.inc to set ARM_INSTRUCTION_SET to thumb and the commit
message explicitly states that the change should have no effect unless
TUNE_FEATURES also includes thumb. This change to rust will allow that
assumption to continue to be true.