### PR TITLE
WIP/RFC: attempt to add nativesdk support

### DIFF
--- a/recipes-devtools/cargo/cargo.inc
+++ b/recipes-devtools/cargo/cargo.inc
@@ -38,7 +38,7 @@ do_install () {
 export LIBGIT2_SYS_USE_PKG_CONFIG = "1"
 export LIBSSH2_SYS_USE_PKG_CONFIG = "1"
 
-BBCLASSEXTEND = "native"
+BBCLASSEXTEND = "native nativesdk"
 
 # When building cargo-native we don't have a built cargo to use so we must use
 # the snapshot to bootstrap the build of cargo

--- a/recipes-devtools/rust/libstd-rs.inc
+++ b/recipes-devtools/rust/libstd-rs.inc
@@ -29,3 +29,5 @@ do_install () {
     rm -f ${B}/${TARGET_SYS}/${BUILD_DIR}/deps/*.d
     cp ${B}/${TARGET_SYS}/${BUILD_DIR}/deps/* ${D}${rustlibdir}
 }
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/rust/rust-llvm.inc
+++ b/recipes-devtools/rust/rust-llvm.inc
@@ -19,7 +19,7 @@ LLVM_DIR = "llvm${LLVM_RELEASE}"
 
 EXTRA_OECMAKE = " \
     -DCMAKE_BUILD_TYPE=Release \
-    -DLLVM_TARGETS_TO_BUILD='X86;ARM;AArch64;PowerPC;Mips' \
+    -DLLVM_TARGETS_TO_BUILD='X86;ARM' \
     -DLLVM_BUILD_DOCS=OFF \
     -DLLVM_ENABLE_TERMINFO=OFF \
     -DLLVM_ENABLE_ZLIB=OFF \
@@ -36,6 +36,12 @@ EXTRA_OECMAKE = " \
 EXTRA_OECMAKE_append_class-target = "\
     -DCMAKE_CROSSCOMPILING:BOOL=ON \
     -DLLVM_BUILD_TOOLS=OFF \
+    -DLLVM_TABLEGEN=${STAGING_LIBDIR_NATIVE}/llvm-rust/bin/llvm-tblgen \
+    -DLLVM_CONFIG_PATH=${STAGING_LIBDIR_NATIVE}/llvm-rust/bin/llvm-config \
+"
+
+EXTRA_OECMAKE_append_class-nativesdk = "\
+    -DCMAKE_CROSSCOMPILING:BOOL=ON \
     -DLLVM_TABLEGEN=${STAGING_LIBDIR_NATIVE}/llvm-rust/bin/llvm-tblgen \
     -DLLVM_CONFIG_PATH=${STAGING_LIBDIR_NATIVE}/llvm-rust/bin/llvm-config \
 "
@@ -59,4 +65,7 @@ FILES_${PN}-staticdev =+ "${libdir}/llvm-rust/*/*.a"
 FILES_${PN} += "${libdir}/libLLVM*.so.* ${libdir}/llvm-rust/lib/*.so.* ${libdir}/llvm-rust/bin"
 FILES_${PN}-dev += "${datadir}/llvm ${libdir}/llvm-rust/lib/*.so ${libdir}/llvm-rust/include ${libdir}/llvm-rust/share ${libdir}/llvm-rust/lib/cmake"
 
-BBCLASSEXTEND = "native"
+FILES_${PN}_append_class-nativesdk = " /usr/share"
+#FILES_nativesdk-${PN}_append_class-nativesdk = " /usr/share ${libdir}"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/rust/rust_1.33.0.bb
+++ b/recipes-devtools/rust/rust_1.33.0.bb
@@ -6,7 +6,10 @@ DEPENDS += "rust-llvm (=${PV})"
 
 # Otherwise we'll depend on what we provide
 INHIBIT_DEFAULT_RUST_DEPS_class-native = "1"
+INHIBIT_DEFAULT_RUST_DEPS_class-nativesdk = "1"
+
 # We don't need to depend on gcc-native because yocto assumes it exists
 PROVIDES_class-native = "virtual/${TARGET_PREFIX}rust"
+PROVIDES_class-nativesdk = "virtual/${SDK_PREFIX}rust"
 
-BBCLASSEXTEND = "native"
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Add nativesdk to rust recipes.

Currently fails running llvm-config:
  Compiling bootstrap v0.0.0 (/home/vagrant/z/build/tmp/work/x86_64-nativesdk-pokysdk-linux/nativesdk-rust/1.33.0-r0/rustc-1.33.0-src/src/bootstrap)
  |     Finished dev [unoptimized] target(s) in 2m 07s
  | running: /home/vagrant/z/build/tmp/work/x86_64-nativesdk-pokysdk-linux/nativesdk-rust/1.33.0-r0/rustc-1.33.0-src/build/bootstrap/debug/bootstrap build --verbose
  |
  |
  | failed to execute command: "/home/vagrant/z/build/tmp/work/x86_64-nativesdk-pokysdk-linux/nativesdk-rust/1.33.0-r0/recipe-sysroot/opt/poky/2.6.1/sysroots/x86_64-pokysdk-linux/usr/lib/llvm-rust/bin/llvm-config" "--bindir"
  | error: No such file or directory (os error 2)

llvm-config does exist at the location though.

Signed-off-by: Stefan Stanacar <sstncr@gmail.com>