### PR TITLE
rust: Improve TUNE_FEATURE parsing

### DIFF
--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -47,6 +47,9 @@ def llvm_features_from_tune(d):
         return []
     feat = frozenset(feat.split())
 
+    mach_overrides = d.getVar('MACHINEOVERRIDES')
+    mach_overrides = frozenset(mach_overrides.split(':'))
+
     if 'vfpv4' in feat:
         f.append("+vfp4")
     if 'vfpv3' in feat:
@@ -70,9 +73,9 @@ def llvm_features_from_tune(d):
         f.append("+mips32r2")
 
     v7=frozenset(['armv7a', 'armv7r', 'armv7m', 'armv7ve'])
-    if not feat.isdisjoint(v7):
+    if (not mach_overrides.isdisjoint(v7)) or (not feat.isdisjoint(v7)):
         f.append("+v7")
-    if 'armv6' in feat:
+    if ('armv6' in mach_overrides) or ('armv6' in feat):
         f.append("+v6")
 
     if 'dsp' in feat:
@@ -80,7 +83,7 @@ def llvm_features_from_tune(d):
 
     if 'thumb' in feat:
         if d.getVar('ARM_THUMB_OPT') is "thumb":
-            if not feat.isdisjoint(v7):
+            if (not mach_overrides.isdisjoint(v7)) or (not feat.isdisjoint(v7)):
                 f.append("+thumb2")
             f.append("+thumb-mode")
 


### PR DESCRIPTION
Since https://github.com/openembedded/openembedded-core/commit/ac83d22eb5031f7fdd09d34a1a46d92fd3e39a3c

The armvX arch definition is not present in TUNE_FEATURES but is now in
MACHINEOVERRIDES. Improve parsing so that MACHINEOVERRIDES is also checked.

Fixes #240

Tested on raspberrypi3 with balenaOS which uses rust.

Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>