### PR TITLE
Fix checksums and patch fuzz from 1.34.2

### DIFF
--- a/recipes-devtools/cargo/cargo/0001-Disable-http2.patch
+++ b/recipes-devtools/cargo/cargo/0001-Disable-http2.patch
@@ -1,4 +1,4 @@
-From a66e33d612d2207154de20e24701b0c30056fe7a Mon Sep 17 00:00:00 2001
+From 44cf21036646e4849e9f8566db7decb7da917394 Mon Sep 17 00:00:00 2001
 From: Johan Anderholm <johan.anderholm@gmail.com>
 Date: Sun, 27 Jan 2019 10:19:00 +0100
 Subject: [PATCH] Disable http2
@@ -9,16 +9,17 @@ curl-native. As long as multiplexing is disabled in cargo this should
 be fine.
 
 Upstream-Status: Inappropriate
+
 ---
  Cargo.toml | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-Index: cargo/Cargo.toml
-===================================================================
---- cargo.orig/Cargo.toml
-+++ cargo/Cargo.toml
+diff --git a/Cargo.toml b/Cargo.toml
+index 8238380861d9..ced1defea459 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
 @@ -24,7 +24,7 @@ bytesize = "1.0"
- crates-io = { path = "src/crates-io", version = "0.22" }
+ crates-io = { path = "src/crates-io", version = "0.23" }
  crossbeam-utils = "0.6"
  crypto-hash = "0.3.1"
 -curl = { version = "0.4.19", features = ['http2'] }

--- a/recipes-devtools/rust/rust-llvm_1.34.2.bb
+++ b/recipes-devtools/rust/rust-llvm_1.34.2.bb
@@ -1,7 +1,7 @@
 require rust-source-${PV}.inc
 require rust-llvm.inc
 
-LIC_FILES_CHKSUM = "file://LICENSE.TXT;md5=c520ed40e11887bb1d24d86f7f5b1f05"
+LIC_FILES_CHKSUM = "file://LICENSE.TXT;md5=c6b766a4e85dd28301eeed54a6684648"
 
 do_install_prepend () {
 	# the install does a sed on this without installing the file

--- a/recipes-devtools/rust/rust-source-1.34.2.inc
+++ b/recipes-devtools/rust/rust-source-1.34.2.inc
@@ -8,4 +8,4 @@ RUSTSRC = "${WORKDIR}/rustc-${PV}-src"
 # set this as our default
 S = "${RUSTSRC}"
 
-LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=66ddc8ecd998476b7cd5732e8c3a6c1d"
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=93a95682d51b4cb0a633a97046940ef0"


### PR DESCRIPTION
1.34.2 changes a number of license texts and a new patch fuzz warning in cargo