### PR TITLE
Set cainfo to certificates in sysroot-native

### DIFF
--- a/classes/cargo_common.bbclass
+++ b/classes/cargo_common.bbclass
@@ -58,6 +58,11 @@ cargo_common_do_configure () {
 		multiplexing = false
 	EOF
 
+	# When a sstate-cache is used sometimes the certificates are not available
+	# at the compile time path anymore. Set it explicitly instead.
+	echo "cainfo = \"${STAGING_ETCDIR_NATIVE}/ssl/certs/ca-certificates.crt\"" \
+		>> ${CARGO_HOME}/config
+
 	if [ -n "${http_proxy}" ]; then
 		echo "proxy = \"${http_proxy}\"" >> ${CARGO_HOME}/config
 	fi


### PR DESCRIPTION
This solves issue #246 

When a sstate-cache is used sometimes the certificates are not available at the compile time path anymore. Typically they point to a file that existed when building another package. Possibly even another user it a shared sstate-cache is used. The required certificates are available in sysroot-native and can be selected with the cainfo configuration instead to solve the connection problems.

