### PR TITLE
rust-cross: Add riscv32 data layout information

### DIFF
--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -223,6 +223,14 @@ TARGET_POINTER_WIDTH[powerpc] = "32"
 TARGET_C_INT_WIDTH[powerpc] = "32"
 MAX_ATOMIC_WIDTH[powerpc] = "32"
 
+## riscv32-unknown-linux-{gnu, musl}
+DATA_LAYOUT[riscv32] = "e-m:e-p:64:64-i64:64-i128:128-n64-S128"
+LLVM_TARGET[riscv32] = "${RUST_TARGET_SYS}"
+TARGET_ENDIAN[riscv32] = "little"
+TARGET_POINTER_WIDTH[riscv32] = "32"
+TARGET_C_INT_WIDTH[riscv32] = "32"
+MAX_ATOMIC_WIDTH[riscv32] = "32"
+
 ## riscv64-unknown-linux-{gnu, musl}
 DATA_LAYOUT[riscv64] = "e-m:e-p:64:64-i64:64-i128:128-n64-S128"
 LLVM_TARGET[riscv64] = "${RUST_TARGET_SYS}"


### PR DESCRIPTION
This was generated with:
    clang --target=riscv32  -emit-llvm -S -x c /dev/null -o aaa |  cat aaa | grep "target datalayout"

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>