### PR TITLE
rust: Use Python3 native for build

### DIFF
--- a/recipes-devtools/rust/rust-llvm.inc
+++ b/recipes-devtools/rust/rust-llvm.inc
@@ -7,7 +7,7 @@ S = "${RUSTSRC}/src/llvm-project/llvm"
 
 LIC_FILES_CHKSUM ?= "file://LICENSE.TXT;md5=4c0bc17c954e99fd547528d938832bfa"
 
-inherit cmake pythonnative
+inherit cmake python3native
 
 DEPENDS += "ninja-native rust-llvm-native"
 

--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -6,7 +6,7 @@ LICENSE = "MIT | Apache-2.0"
 inherit rust
 inherit cargo_common
 
-DEPENDS += "file-native python-native"
+DEPENDS += "file-native python3-native"
 DEPENDS_append_class-native = " rust-llvm-native"
 
 # We generate local targets, and need to be able to locate them
@@ -474,7 +474,7 @@ rust_runx () {
 
     oe_cargo_fix_env
 
-    python src/bootstrap/bootstrap.py "$@" --verbose
+    python3 src/bootstrap/bootstrap.py "$@" --verbose
 }
 
 do_compile () {


### PR DESCRIPTION
Use Python3 as the native Python instead of Python2.

Signed-off-by: Alistair Francis <alistair@alistair23.me>