### PR TITLE
Avoid extra sh process from shell wrapper

### DIFF
--- a/classes/rust-common.bbclass
+++ b/classes/rust-common.bbclass
@@ -110,7 +110,7 @@ create_wrapper () {
 
 	cat <<- EOF > "${file}"
 	#!/bin/sh
-	$@ "\$@"
+	exec $@ "\$@"
 	EOF
 	chmod +x "${file}"
 }


### PR DESCRIPTION
Super insignificant micro-optimisation:
`exec` from shell wrapper to avoid persistent sh process