### PR TITLE
rust.inc: whitelist BB_NUMBER_THREADS in do_compile

### DIFF
--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -465,6 +465,7 @@ rust_runx () {
 
     python3 src/bootstrap/bootstrap.py -j ${BB_NUMBER_THREADS} "$@" --verbose
 }
+rust_runx[vardepsexclude] += "BB_NUMBER_THREADS"
 
 do_compile () {
     rust_runx build


### PR DESCRIPTION
d55cce6b8b6b510bf4905f19b949f7995af57a4d added a use of
BB_NUMBER_THREADS which is not whitelisted in Poky. This caused machines
with a different number of CPUs to have different sstate for
rust-native.