### PR TITLE
rust: use PARALLEL_MAKE instead of BB_NUMBER_THREADS

### DIFF
--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -463,9 +463,9 @@ rust_runx () {
 
     oe_cargo_fix_env
 
-    python3 src/bootstrap/bootstrap.py -j ${BB_NUMBER_THREADS} "$@" --verbose
+    python3 src/bootstrap/bootstrap.py ${@oe.utils.parallel_make_argument(d, '-j %d')} "$@" --verbose
 }
-rust_runx[vardepsexclude] += "BB_NUMBER_THREADS"
+rust_runx[vardepsexclude] += "PARALLEL_MAKE"
 
 do_compile () {
     rust_runx build


### PR DESCRIPTION
* BB_NUMBER_THREADS is number of bitbake tasks running in
  parallel, not parallelization inside individual tasks
* use oe.utils.parallel_make_argument to make sure it
  works even when people add e.g. "-l 10" in PARALLEL_MAKE
* with the recent improvements for rust-native build time, I wanted
  to rerun some build time tests from
  https://github.com/shr-project/test-oe-build-time
  here are the results on AMD Threadripper 3970x with 128GB ram:

  BB is BB_NUMBER_THREADS
  PM is PARALLEL_MAKE
```
  TIME   BB        PM   Description
  20:50   *         *   zeus based build with 1.37 rust (BB/PM has no impact)
  14:50   8  32,48,64   dunfell, 1.43 as in https://github.com/meta-rust/meta-rust/commit/d2ff87ca5545b8081b16ac8f53ed4295593208c6 (PM has no impact, because bootstrap uses BB)
   9:50   8  32,48,64   dunfell, 1.43 with this patch applied, it doesn't get faster after some threashold of PM
  13:32   8        64   dunfell, 1.43 with this patch applied and "rust.inc: cut build time in half" (https://github.com/meta-rust/meta-rust/commit/afcb58e5b9cbda7efb1c8a12c980cb2f583728bd) reverted
  13:30   8        64   dunfell, 1.43 with "rust.inc: cut build time in half" (https://github.com/meta-rust/meta-rust/commit/afcb58e5b9cbda7efb1c8a12c980cb2f583728bd) as well as "rust.inc: run bootstrap.py in parallel" (https://github.com/meta-rust/meta-rust/commit/40a6bd8a8d943eff495c7fdeb0bf8452891f6f99) reverted to see if 1.43 builds faster without any meta-rust improvements compared to 1.37
  94:47   1        64   dunfell, 1.43 as in https://github.com/meta-rust/meta-rust/commit/d2ff87ca5545b8081b16ac8f53ed4295593208c6 (either something went wrong or explicit "-j 1" disables some parallelism done by default already
  13:40   *         *   zeus based build with 1.39 rust (BB/PM has no impact)
  10:50   8        64   zeus based build with 1.39 rust as proposed in jansa/new-zeus-branch
  80:51   8         1   zeus based build with 1.39 rust as proposed in jansa/new-zeus-branch with "-j 1" PARALLEL_MAKE
```
Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>