### PR TITLE
rust-bin.bbclass: Do not use append and += together

### DIFF
--- a/classes/rust-bin.bbclass
+++ b/classes/rust-bin.bbclass
@@ -1,6 +1,6 @@
 inherit rust
 
-RDEPENDS_${PN}_append_class-target += "${RUSTLIB_DEP}"
+RDEPENDS_${PN}_append_class-target = " ${RUSTLIB_DEP}"
 
 RUSTC_ARCHFLAGS += "-C opt-level=3 -g -L ${STAGING_DIR_HOST}/${rustlibdir} -C linker=${RUST_TARGET_CCLD}"
 EXTRA_OEMAKE += 'RUSTC_ARCHFLAGS="${RUSTC_ARCHFLAGS}"'


### PR DESCRIPTION
this is undefined behavior in bitbake, prepend space instead

Signed-off-by: Khem Raj <raj.khem@gmail.com>