### PR TITLE
cargo: add missing version 1.46.0

### DIFF
--- a/recipes-devtools/cargo/cargo-1.46.0/0001-Disable-http2.patch
+++ b/recipes-devtools/cargo/cargo-1.46.0/0001-Disable-http2.patch
@@ -1,0 +1,31 @@
+From 8ea4e279b04f2aad3673cd1677bc7b6ee944d638 Mon Sep 17 00:00:00 2001
+From: Johan Anderholm <johan.anderholm@gmail.com>
+Date: Sun, 27 Jan 2019 10:19:00 +0100
+Subject: [PATCH] Disable http2
+
+http2 requires that curl is build with nghttp2 which in turn depends on
+many dependencies and ultimately a dependency loop in the case of
+curl-native. As long as multiplexing is disabled in cargo this should
+be fine.
+
+Upstream-Status: Inappropriate
+---
+ Cargo.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Cargo.toml b/Cargo.toml
+index 61006215d..c1a23ab83 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -25,7 +25,7 @@ cargo-platform = { path = "crates/cargo-platform", version = "0.1.1" }
+ crates-io = { path = "crates/crates-io", version = "0.31.1" }
+ crossbeam-utils = "0.7"
+ crypto-hash = "0.3.1"
+-curl = { version = "0.4.23", features = ["http2"] }
++curl = { version = "0.4.23" }
+ curl-sys = "0.4.22"
+ env_logger = "0.7.0"
+ pretty_env_logger = { version = "0.4", optional = true }
+-- 
+2.28.0
+

--- a/recipes-devtools/cargo/cargo_1.46.0.bb
+++ b/recipes-devtools/cargo/cargo_1.46.0.bb
@@ -1,0 +1,8 @@
+require recipes-devtools/rust/rust-source-${PV}.inc
+require recipes-devtools/rust/rust-snapshot-${PV}.inc
+require cargo.inc
+
+LIC_FILES_CHKSUM += " \
+    file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
+    file://LICENSE-THIRD-PARTY;md5=f257ad009884cb88a3a87d6920e7180a \
+"


### PR DESCRIPTION
Rust version 1.46.0 was added to the layer a while back, but the
corresponding cargo recipe seems to have been missed.