### PR TITLE
Build separation

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -15,16 +15,19 @@ BASEDEPENDS_append = " cargo-native"
 DEPENDS_append_class-target = " virtual/${TARGET_PREFIX}rust ${RUSTLIB_DEP}"
 DEPENDS_append_class-native = " rust-native"
 
-# Cargo only supports in-tree builds at the moment
-B = "${S}"
+# Enable build separation
+B = "${WORKDIR}/build"
 
 # In case something fails in the build process, give a bit more feedback on
 # where the issue occured
 export RUST_BACKTRACE = "1"
 
+# Assume there's a Cargo.toml directly in the source directory
+MANIFEST_PATH ??= "${S}/Cargo.toml"
+
 RUSTFLAGS ??= ""
 BUILD_MODE = "${@['--release', ''][d.getVar('DEBUG_BUILD') == '1']}"
-CARGO_BUILD_FLAGS = "-v --target ${HOST_SYS} ${BUILD_MODE}"
+CARGO_BUILD_FLAGS = "-v --target ${HOST_SYS} ${BUILD_MODE} --manifest-path=${MANIFEST_PATH}"
 
 # This is based on the content of CARGO_BUILD_FLAGS and generally will need to
 # change if CARGO_BUILD_FLAGS changes.

--- a/classes/cargo_common.bbclass
+++ b/classes/cargo_common.bbclass
@@ -73,6 +73,17 @@ cargo_common_do_configure () {
 		echo "[target.${BUILD_SYS}]" >> ${CARGO_HOME}/config
 		echo "linker = '${RUST_BUILD_CCLD}'" >> ${CARGO_HOME}/config
 	fi
+
+	# Put build output in build directory preferred by bitbake instead of
+	# inside source directory unless they are the same
+	if [ "${B}" != "${S}" ]; then
+		cat <<- EOF >> ${CARGO_HOME}/config
+
+		[build]
+		# Use out of tree build destination to avoid poluting the source tree
+		target-dir = "${B}/target"
+		EOF
+	fi
 }
 
 oe_cargo_fix_env () {

--- a/recipes-devtools/cargo/cargo.inc
+++ b/recipes-devtools/cargo/cargo.inc
@@ -29,7 +29,7 @@ do_compile_prepend () {
 
 do_install () {
 	install -d "${D}${bindir}"
-	install -m 755 "${RUSTSRC}/target/${CARGO_TARGET_SUBDIR}/cargo" "${D}${bindir}"
+	install -m 755 "${B}/target/${CARGO_TARGET_SUBDIR}/cargo" "${D}${bindir}"
 }
 
 # Disabled due to incompatibility with libgit2 0.28.x (https://github.com/rust-lang/git2-rs/issues/458, https://bugs.gentoo.org/707746#c1)


### PR DESCRIPTION
The first commit enables build separation where the build directory is placed outside of the source directory. This is how most packages are built with bitbake and makes it possible to share the source directory between different machines without risking cross contamination.

The second simply makes cargo_home/config a bit more readable with in-line descriptive comments. The content should be identical.