### PR TITLE
rust-llvm: Use early variable assignment for the license checksum in …

### DIFF
--- a/recipes-devtools/rust/rust-llvm.inc
+++ b/recipes-devtools/rust/rust-llvm.inc
@@ -5,7 +5,7 @@ SRC_URI += "file://0002-llvm-allow-env-override-of-exe-path.patch"
 
 S = "${RUSTSRC}/src/llvm-project/llvm"
 
-LIC_FILES_CHKSUM = "file://LICENSE.TXT;md5=8a15a0759ef07f2682d2ba4b893c9afe"
+LIC_FILES_CHKSUM ?= "file://LICENSE.TXT;md5=8a15a0759ef07f2682d2ba4b893c9afe"
 
 inherit cmake python3native
 


### PR DESCRIPTION
…rust-llvm.inc

Because rust-llvm-ncsa.inc requires rust-llvm.inc we do not want that
the latter overrides the license checksum set in the former.

Signed-off-by: Florin Sarbu <florin@balena.io>