### PR TITLE
cargo: Mark the cargo-native dependency specific to target

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -9,7 +9,7 @@ inherit cargo_common
 CARGO = "cargo"
 
 # We need cargo to compile for the target
-BASEDEPENDS_append = " cargo-native"
+BASEDEPENDS_append_class-target = " cargo-native"
 
 # Ensure we get the right rust variant
 DEPENDS_append_class-target = " virtual/${TARGET_PREFIX}rust ${RUSTLIB_DEP}"


### PR DESCRIPTION
Fixes dependency loop

These are usually caused by circular dependencies and any circular dependency chains found will be printed below. Increase the debug level to see a list of unbuildable tasks.

Identifying dependency loops (this may take a short while)...

ERROR:
Dependency loop #1 found:
  Task virtual:native:/mnt/b/yoe/master/sources/meta-rust/recipes-devtools/cargo/cargo_1.47.0.bb:do_compile (dependent Tasks ['cargo_1.47.0.bb:do_configure'])
  Task virtual:native:/mnt/b/yoe/master/sources/meta-rust/recipes-devtools/cargo/cargo_1.47.0.bb:do_install (dependent Tasks ['cargo_1.47.0.bb:do_compile'])
  Task virtual:native:/mnt/b/yoe/master/sources/meta-rust/recipes-devtools/cargo/cargo_1.47.0.bb:do_populate_sysroot (dependent Tasks ['cargo_1.47.0.bb:do_install'])
  Task virtual:native:/mnt/b/yoe/master/sources/meta-rust/recipes-devtools/cargo/cargo_1.47.0.bb:do_prepare_recipe_sysroot (dependent Tasks ['cargo_1.47.0.bb:do_populate_sysroot', 'openssl_1.1.1i.bb:do_populate_sysroot', 'curl_7.74.0.bb:do_populate_sysroot', 'rust_1.47.0.bb:do_populate_sysroot', 'zlib_1.2.11.bb:do_populate_sysroot', 'ca-certificates_20210119.bb:do_populate_sysroot', 'libssh2_1.9.0.bb:do_populate_sysroot', 'cargo_1.47.0.bb:do_fetch'])
  Task virtual:native:/mnt/b/yoe/master/sources/meta-rust/recipes-devtools/cargo/cargo_1.47.0.bb:do_configure (dependent Tasks ['cargo_1.47.0.bb:do_prepare_recipe_sysroot', 'cargo_1.47.0.bb:do_patch', 'cargo_1.47.0.bb:do_rust_create_wrappers', 'cargo_1.47.0.bb:do_cargo_setup_snapshot'])

ERROR: Command execution failed: 1

Signed-off-by: Khem Raj <raj.khem@gmail.com>