### PR TITLE
cargo: break dependency loop

### DIFF
--- a/recipes-devtools/cargo/cargo.inc
+++ b/recipes-devtools/cargo/cargo.inc
@@ -46,3 +46,4 @@ BBCLASSEXTEND = "native"
 # When building cargo-native we don't have a built cargo to use so we must use
 # the snapshot to bootstrap the build of cargo
 CARGO_class-native = "${WORKDIR}/${CARGO_SNAPSHOT}/bin/cargo"
+DEPENDS_remove_class-native = "cargo-native"


### PR DESCRIPTION
Since this commit (found by bisecting) in oe-core:
   fd6a007efa native: Stop clearing PACKAGES

There is a dependency loop at parse time for cargo:

Dependency loop #1 found:
  Task virtual:native:/.../recipes-devtools/cargo/cargo_1.47.0.bb:do_compile (dependent Tasks ['cargo_1.47.0.bb:do_configure'])
  Task virtual:native:/.../recipes-devtools/cargo/cargo_1.47.0.bb:do_install (dependent Tasks ['cargo_1.47.0.bb:do_compile'])
  Task virtual:native:/.../recipes-devtools/cargo/cargo_1.47.0.bb:do_populate_sysroot (dependent Tasks ['cargo_1.47.0.bb:do_install'])
  Task virtual:native:/.../recipes-devtools/cargo/cargo_1.47.0.bb:do_prepare_recipe_sysroot (dependent Tasks ['cargo_1.47.0.bb:do_fetch', 'cargo_1.47.0.bb:do_populate_sysroot', 'zlib_1.2.11.bb:do_populate_sysroot', 'openssl_1.1.1i.bb:do_populate_sysroot', 'rust_1.47.0.bb:do_populate_sysroot', 'ca-certificates_20210119.bb:do_populate_sysroot', 'curl_7.74.0.bb:do_populate_sysroot', 'libssh2_1.8.2.bb:do_populate_sysroot'])
  Task virtual:native:/.../recipes-devtools/cargo/cargo_1.47.0.bb:do_configure (dependent Tasks ['cargo_1.47.0.bb:do_cargo_setup_snapshot', 'cargo_1.47.0.bb:do_patch', 'cargo_1.47.0.bb:do_rust_create_wrappers', 'cargo_1.47.0.bb:do_prepare_recipe_sysroot'])

Break this loop by removing the dependency of cargo-native on itself.

Signed-off-by: Randy MacLeod <Randy.MacLeod@windriver.com>