### PR TITLE
add rust 1.49.0

### DIFF
--- a/recipes-devtools/cargo/cargo-1.49.0/0001-Disable-http2.patch
+++ b/recipes-devtools/cargo/cargo-1.49.0/0001-Disable-http2.patch
@@ -1,0 +1,31 @@
+From 7f8a197af9c33d0575187663f796f882064136dc Mon Sep 17 00:00:00 2001
+From: Johan Anderholm <johan.anderholm@gmail.com>
+Date: Sun, 27 Jan 2019 10:19:00 +0100
+Subject: [PATCH] Disable http2
+
+http2 requires that curl is build with nghttp2 which in turn depends on
+many dependencies and ultimately a dependency loop in the case of
+curl-native. As long as multiplexing is disabled in cargo this should
+be fine.
+
+Upstream-Status: Inappropriate
+---
+ Cargo.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Cargo.toml b/Cargo.toml
+index fde0a3188..a4a51939a 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -25,7 +25,7 @@ cargo-platform = { path = "crates/cargo-platform", version = "0.1.1" }
+ crates-io = { path = "crates/crates-io", version = "0.31.1" }
+ crossbeam-utils = "0.8"
+ crypto-hash = "0.3.1"
+-curl = { version = "0.4.23", features = ["http2"] }
++curl = { version = "0.4.23" }
+ curl-sys = "0.4.22"
+ env_logger = "0.8.1"
+ pretty_env_logger = { version = "0.4", optional = true }
+-- 
+2.28.0
+

--- a/recipes-devtools/cargo/cargo_1.49.0.bb
+++ b/recipes-devtools/cargo/cargo_1.49.0.bb
@@ -1,0 +1,8 @@
+require recipes-devtools/rust/rust-source-${PV}.inc
+require recipes-devtools/rust/rust-snapshot-${PV}.inc
+require cargo.inc
+
+LIC_FILES_CHKSUM += " \
+    file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
+    file://LICENSE-THIRD-PARTY;md5=f257ad009884cb88a3a87d6920e7180a \
+"

--- a/recipes-devtools/rust/libstd-rs_1.49.0.bb
+++ b/recipes-devtools/rust/libstd-rs_1.49.0.bb
@@ -1,0 +1,5 @@
+require rust-source-${PV}.inc
+require libstd-rs.inc
+
+# libstd moved from src/libstd to library/std in 1.47+
+S = "${RUSTSRC}/library/std"

--- a/recipes-devtools/rust/rust-cross_1.49.0.bb
+++ b/recipes-devtools/rust/rust-cross_1.49.0.bb
@@ -1,0 +1,2 @@
+require rust-cross.inc
+require rust-source-${PV}.inc

--- a/recipes-devtools/rust/rust-llvm_1.49.0.bb
+++ b/recipes-devtools/rust/rust-llvm_1.49.0.bb
@@ -1,0 +1,2 @@
+require rust-source-${PV}.inc
+require rust-llvm.inc

--- a/recipes-devtools/rust/rust-snapshot-1.49.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.49.0.inc
@@ -1,0 +1,21 @@
+## This is information on the rust-snapshot (binary) used to build our current release.
+## snapshot info is taken from rust/src/stage0.txt
+## TODO: find a way to add additional SRC_URIs based on the contents of an
+##       earlier SRC_URI.
+RS_VERSION = "1.48.0"
+
+RUSTC_SNAPSHOT = "rustc-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
+RUST_STD_SNAPSHOT = "rust-std-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
+CARGO_VERSION = "1.48.0"
+CARGO_SNAPSHOT = "cargo-${CARGO_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
+
+SRC_URI += " \
+	https://static.rust-lang.org/dist/${RUSTC_SNAPSHOT}.tar.xz;name=rustc-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
+	https://static.rust-lang.org/dist/${RUST_STD_SNAPSHOT}.tar.xz;name=rust-std-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
+	https://static.rust-lang.org/dist/${CARGO_SNAPSHOT}.tar.xz;name=cargo-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
+	"
+
+# TODO: Add hashes for other architecture toolchains as well. Make a script?
+SRC_URI[rust-std-snapshot-x86_64.sha256sum] = "1c00a6a0dabbf6290728b09f9307d9fa6cc985487f727075c68acd4a600ef3f8"
+SRC_URI[rustc-snapshot-x86_64.sha256sum] = "fc4d292a52cbb6b84fb9f065d0d7596064a9b957381d639d5a750d6e2bf02483"
+SRC_URI[cargo-snapshot-x86_64.sha256sum] = "b11d595581e2580c069b5039214e1031a0e4f87ff6490ac39f92f77857e37055"

--- a/recipes-devtools/rust/rust-source-1.49.0.inc
+++ b/recipes-devtools/rust/rust-source-1.49.0.inc
@@ -1,0 +1,10 @@
+SRC_URI += "https://static.rust-lang.org/dist/rustc-${PV}-src.tar.xz;name=rust"
+
+SRC_URI[rust.sha256sum] = "ebe910edc824a0a037a10be443446a0511923ba8342fa3c331ec8a22481d5d15"
+
+# later versions of rust change the directory that they unextract to
+RUSTSRC = "${WORKDIR}/rustc-${PV}-src"
+# set this as our default
+S = "${RUSTSRC}"
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=93a95682d51b4cb0a633a97046940ef0"

--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -463,7 +463,18 @@ python do_configure() {
     # nothing about when trying to build some stage0 tools (like fabricate)
     config.set("build", "build", e(d.getVar("SNAPSHOT_BUILD_SYS", True)))
 
+    # [install]
+    config.add_section("install")
+    # ./x.py install doesn't have any notion of "destdir"
+    # but we can prepend ${D} to all the directories instead
+    config.set("install", "prefix",  e(d.getVar("D", True) + d.getVar("prefix", True)))
+    config.set("install", "bindir",  e(d.getVar("D", True) + d.getVar("bindir", True)))
+    config.set("install", "libdir",  e(d.getVar("D", True) + d.getVar("libdir", True)))
+    config.set("install", "datadir", e(d.getVar("D", True) + d.getVar("datadir", True)))
+    config.set("install", "mandir",  e(d.getVar("D", True) + d.getVar("mandir", True)))
+
     with open("config.toml", "w") as f:
+        f.write('changelog-seen = 2\n\n')
         config.write(f)
 
     # set up ${WORKDIR}/cargo_home
@@ -500,7 +511,9 @@ rust_do_install () {
     cp -pRd build/${HOST_SYS}/stage2/lib/* ${D}${libdir}
     # Remove absolute symlink so bitbake doesn't complain
     rm -f ${D}${libdir}/rustlib/src/rust
+}
 
+rust_install_targets() {
     # Install our custom target.json files
     local td="${D}${libdir}/rustlib/"
     install -d "$td"
@@ -512,5 +525,6 @@ rust_do_install () {
 
 do_install () {
     rust_do_install
+    rust_install_targets
 }
 # ex: sts=4 et sw=4 ts=8

--- a/recipes-devtools/rust/rust/0001-rustc_target-Fix-dash-vs-underscore-mismatches-in-op.patch
+++ b/recipes-devtools/rust/rust/0001-rustc_target-Fix-dash-vs-underscore-mismatches-in-op.patch
@@ -1,0 +1,75 @@
+From dd682cb48c8b667859dded98a4bbfbd891a1eca4 Mon Sep 17 00:00:00 2001
+From: Vadim Petrochenkov <vadim.petrochenkov@gmail.com>
+Date: Thu, 12 Nov 2020 19:16:59 +0300
+Subject: [PATCH] rustc_target: Fix dash vs underscore mismatches in option
+ names
+
+---
+ compiler/rustc_target/src/spec/mod.rs | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
+index f949bf95a50..f837114ee74 100644
+--- a/compiler/rustc_target/src/spec/mod.rs
++++ b/compiler/rustc_target/src/spec/mod.rs
+@@ -1428,8 +1428,8 @@ pub fn from_json(obj: Json) -> Result<Target, String> {
+         }
+ 
+         key!(is_builtin, bool);
+-        key!(endian = "target_endian");
+-        key!(c_int_width = "target_c_int_width");
++        key!(endian = "target-endian");
++        key!(c_int_width = "target-c-int-width");
+         key!(os);
+         key!(env);
+         key!(vendor);
+@@ -1466,7 +1466,7 @@ pub fn from_json(obj: Json) -> Result<Target, String> {
+         key!(exe_suffix);
+         key!(staticlib_prefix);
+         key!(staticlib_suffix);
+-        key!(os_family = "target_family", optional);
++        key!(os_family = "target-family", optional);
+         key!(abi_return_struct_as_int, bool);
+         key!(is_like_osx, bool);
+         key!(is_like_solaris, bool);
+@@ -1511,7 +1511,7 @@ pub fn from_json(obj: Json) -> Result<Target, String> {
+         key!(limit_rdylib_exports, bool);
+         key!(override_export_symbols, opt_list);
+         key!(merge_functions, MergeFunctions)?;
+-        key!(mcount = "target_mcount");
++        key!(mcount = "target-mcount");
+         key!(llvm_abiname);
+         key!(relax_elf_relocations, bool);
+         key!(llvm_args, list);
+@@ -1663,8 +1663,8 @@ fn to_json(&self) -> Json {
+         target_val!(data_layout);
+ 
+         target_option_val!(is_builtin);
+-        target_option_val!(endian, "target_endian");
+-        target_option_val!(c_int_width, "target_c_int_width");
++        target_option_val!(endian, "target-endian");
++        target_option_val!(c_int_width, "target-c-int-width");
+         target_option_val!(os);
+         target_option_val!(env);
+         target_option_val!(vendor);
+@@ -1701,7 +1701,7 @@ fn to_json(&self) -> Json {
+         target_option_val!(exe_suffix);
+         target_option_val!(staticlib_prefix);
+         target_option_val!(staticlib_suffix);
+-        target_option_val!(os_family, "target_family");
++        target_option_val!(os_family, "target-family");
+         target_option_val!(abi_return_struct_as_int);
+         target_option_val!(is_like_osx);
+         target_option_val!(is_like_solaris);
+@@ -1746,7 +1746,7 @@ fn to_json(&self) -> Json {
+         target_option_val!(limit_rdylib_exports);
+         target_option_val!(override_export_symbols);
+         target_option_val!(merge_functions);
+-        target_option_val!(mcount, "target_mcount");
++        target_option_val!(mcount, "target-mcount");
+         target_option_val!(llvm_abiname);
+         target_option_val!(relax_elf_relocations);
+         target_option_val!(llvm_args);
+-- 
+2.28.0
+

--- a/recipes-devtools/rust/rust_1.49.0.bb
+++ b/recipes-devtools/rust/rust_1.49.0.bb
@@ -1,0 +1,24 @@
+require rust.inc
+require rust-source-${PV}.inc
+require rust-snapshot-${PV}.inc
+
+SRC_URI += "\
+    file://0001-rustc_target-Fix-dash-vs-underscore-mismatches-in-op.patch \
+    "
+
+DEPENDS += "rust-llvm (=${PV})"
+
+# Otherwise we'll depend on what we provide
+INHIBIT_DEFAULT_RUST_DEPS_class-native = "1"
+# We don't need to depend on gcc-native because yocto assumes it exists
+PROVIDES_class-native = "virtual/${TARGET_PREFIX}rust"
+
+do_compile () {
+    rust_runx build --stage 2
+}
+
+rust_do_install() {
+    rust_runx install
+}
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
Now it seems `./x.py install` is the only way to assemble a fully
working stage 2 cross-built compiler. See rust-lang/rust#81702.

Fixes #292.