### PR TITLE
Few more cleanups

### DIFF
--- a/recipes-devtools/rust/rust-snapshot-1.34.2.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.34.2.inc
@@ -8,9 +8,6 @@ RS_VERSION = "1.33.0"
 CARGO_VERSION = "0.34.0"
 
 # TODO: Add hashes for other architecture toolchains as well. Make a script?
-SRC_URI[rustc-snapshot-x86_64.md5sum] = "bd776f3721f1b86d2f52bedcf25c8a9b"
 SRC_URI[rustc-snapshot-x86_64.sha256sum] = "57c5ced1a826d34f26e50adf041528dd0000f2a59e8be32d2359386843382ce1"
-SRC_URI[rust-std-snapshot-x86_64.md5sum] = "4f9f3be1f62b1e392efd100602654747"
 SRC_URI[rust-std-snapshot-x86_64.sha256sum] = "6f20343ed73faf5fdfc423bec38a9bb1910a0a962af6f2dddd7184407543ed0e"
-SRC_URI[cargo-snapshot-x86_64.md5sum] = "ead4551e9fd773a3f212ac6a49c4c784"
 SRC_URI[cargo-snapshot-x86_64.sha256sum] = "1730c8ebcacc1327eb28b328cb9f5a2c612bb3d9efff9c350647adf19f304e15"

--- a/recipes-devtools/rust/rust-snapshot-1.34.2.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.34.2.inc
@@ -1,24 +1,16 @@
+require rust-snapshot.inc
+
 ## This is information on the rust-snapshot (binary) used to build our current release.
 ## snapshot info is taken from rust/src/stage0.txt
 ## TODO: find a way to add additional SRC_URIs based on the contents of an
 ##       earlier SRC_URI.
 RS_VERSION = "1.33.0"
-
-RUST_STD_SNAPSHOT = "rust-std-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
-RUSTC_SNAPSHOT = "rustc-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
 CARGO_VERSION = "0.34.0"
-CARGO_SNAPSHOT = "cargo-${CARGO_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
-
-SRC_URI += " \
-	https://static.rust-lang.org/dist/${RUST_STD_SNAPSHOT}.tar.gz;name=rust-std-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	https://static.rust-lang.org/dist/${RUSTC_SNAPSHOT}.tar.gz;name=rustc-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	https://static.rust-lang.org/dist/${CARGO_SNAPSHOT}.tar.gz;name=cargo-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	"
 
 # TODO: Add hashes for other architecture toolchains as well. Make a script?
-SRC_URI[rustc-snapshot-x86_64.md5sum] = "c1ec989c1965dce754dda1e54274a68c"
-SRC_URI[rustc-snapshot-x86_64.sha256sum] = "54a342f718b712d8a17fd7878ebd37d22a82ebc70b59c421168cd4153fd04c2b"
-SRC_URI[rust-std-snapshot-x86_64.md5sum] = "d573c5bd3a965c973734c1606968a91e"
-SRC_URI[rust-std-snapshot-x86_64.sha256sum] = "661c2ba717ae1502f002b4c6e7aeb8941685c7ea8fe7ac26ed9ede26f615b7af"
-SRC_URI[cargo-snapshot-x86_64.md5sum] = "de0e635afa9bf495cefecea476bfce36"
-SRC_URI[cargo-snapshot-x86_64.sha256sum] = "4795ae5ca3bb8c7c83ca338676bb02b670efa1eb474e346284b629dc872bcce8"
+SRC_URI[rustc-snapshot-x86_64.md5sum] = "bd776f3721f1b86d2f52bedcf25c8a9b"
+SRC_URI[rustc-snapshot-x86_64.sha256sum] = "57c5ced1a826d34f26e50adf041528dd0000f2a59e8be32d2359386843382ce1"
+SRC_URI[rust-std-snapshot-x86_64.md5sum] = "4f9f3be1f62b1e392efd100602654747"
+SRC_URI[rust-std-snapshot-x86_64.sha256sum] = "6f20343ed73faf5fdfc423bec38a9bb1910a0a962af6f2dddd7184407543ed0e"
+SRC_URI[cargo-snapshot-x86_64.md5sum] = "ead4551e9fd773a3f212ac6a49c4c784"
+SRC_URI[cargo-snapshot-x86_64.sha256sum] = "1730c8ebcacc1327eb28b328cb9f5a2c612bb3d9efff9c350647adf19f304e15"

--- a/recipes-devtools/rust/rust-snapshot-1.36.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.36.0.inc
@@ -8,9 +8,6 @@ RS_VERSION = "1.35.0"
 CARGO_VERSION = "0.36.0"
 
 # TODO: Add hashes for other architecture toolchains as well. Make a script?
-SRC_URI[rustc-snapshot-x86_64.md5sum] = "47ea78f6b3f68e30f24b9c94e465d6bd"
 SRC_URI[rustc-snapshot-x86_64.sha256sum] = "5d6dc216ba429ddf3a1657e70f3e5e380549b546fe56de897677a11d72aa4e07"
-SRC_URI[rust-std-snapshot-x86_64.md5sum] = "348ec23ca8e47fc65079bc80e63cca5f"
 SRC_URI[rust-std-snapshot-x86_64.sha256sum] = "ccff05d0e2d88499505b10f8e33e8b1645df057f918edc81f8acb0fcee9f90b2"
-SRC_URI[cargo-snapshot-x86_64.md5sum] = "93a375e771f3d9b3a139e612dd4730ee"
 SRC_URI[cargo-snapshot-x86_64.sha256sum] = "ab5a6ff1947463dbd2477ca5dac2012494dae821112098ae0c54add652adfdc3"

--- a/recipes-devtools/rust/rust-snapshot-1.36.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.36.0.inc
@@ -1,19 +1,11 @@
+require rust-snapshot.inc
+
 ## This is information on the rust-snapshot (binary) used to build our current release.
 ## snapshot info is taken from rust/src/stage0.txt
 ## TODO: find a way to add additional SRC_URIs based on the contents of an
 ##       earlier SRC_URI.
 RS_VERSION = "1.35.0"
-
-RUSTC_SNAPSHOT = "rustc-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
-RUST_STD_SNAPSHOT = "rust-std-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
 CARGO_VERSION = "0.36.0"
-CARGO_SNAPSHOT = "cargo-${CARGO_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
-
-SRC_URI += " \
-	https://static.rust-lang.org/dist/${RUSTC_SNAPSHOT}.tar.xz;name=rustc-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	https://static.rust-lang.org/dist/${RUST_STD_SNAPSHOT}.tar.xz;name=rust-std-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	https://static.rust-lang.org/dist/${CARGO_SNAPSHOT}.tar.xz;name=cargo-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	"
 
 # TODO: Add hashes for other architecture toolchains as well. Make a script?
 SRC_URI[rustc-snapshot-x86_64.md5sum] = "47ea78f6b3f68e30f24b9c94e465d6bd"

--- a/recipes-devtools/rust/rust-snapshot-1.37.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.37.0.inc
@@ -1,19 +1,11 @@
+require rust-snapshot.inc
+
 ## This is information on the rust-snapshot (binary) used to build our current release.
 ## snapshot info is taken from rust/src/stage0.txt
 ## TODO: find a way to add additional SRC_URIs based on the contents of an
 ##       earlier SRC_URI.
 RS_VERSION = "1.36.0"
-
-RUSTC_SNAPSHOT = "rustc-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
-RUST_STD_SNAPSHOT = "rust-std-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
 CARGO_VERSION = "0.37.0"
-CARGO_SNAPSHOT = "cargo-${CARGO_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
-
-SRC_URI += " \
-	https://static.rust-lang.org/dist/${RUSTC_SNAPSHOT}.tar.xz;name=rustc-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	https://static.rust-lang.org/dist/${RUST_STD_SNAPSHOT}.tar.xz;name=rust-std-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	https://static.rust-lang.org/dist/${CARGO_SNAPSHOT}.tar.xz;name=cargo-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	"
 
 # TODO: Add hashes for other architecture toolchains as well. Make a script?
 SRC_URI[rustc-snapshot-x86_64.md5sum] = "ec27794c94cc1df1a0a69f7244a09176"

--- a/recipes-devtools/rust/rust-snapshot-1.37.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.37.0.inc
@@ -8,9 +8,6 @@ RS_VERSION = "1.36.0"
 CARGO_VERSION = "0.37.0"
 
 # TODO: Add hashes for other architecture toolchains as well. Make a script?
-SRC_URI[rustc-snapshot-x86_64.md5sum] = "ec27794c94cc1df1a0a69f7244a09176"
 SRC_URI[rustc-snapshot-x86_64.sha256sum] = "fff0158da6f5af2a89936dc3e0c361077c06c2983eb310615e02f81ebbde1416"
-SRC_URI[rust-std-snapshot-x86_64.md5sum] = "b71a6fd6f44527c3bf09584e89ad8958"
 SRC_URI[rust-std-snapshot-x86_64.sha256sum] = "ce8e12684b568a8a4f7d346a743383429849cf3f028f5712ad3d3e31590c8db3"
-SRC_URI[cargo-snapshot-x86_64.md5sum] = "8c661276a0da7a1aa48affbe33b347e6"
 SRC_URI[cargo-snapshot-x86_64.sha256sum] = "d20fa121951339d5492cf8862f8a7af59efc99d18f3c27b95ab6d4658b6a7d67"

--- a/recipes-devtools/rust/rust-snapshot-1.39.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.39.0.inc
@@ -1,19 +1,11 @@
+require rust-snapshot.inc
+
 ## This is information on the rust-snapshot (binary) used to build our current release.
 ## snapshot info is taken from rust/src/stage0.txt
 ## TODO: find a way to add additional SRC_URIs based on the contents of an
 ##       earlier SRC_URI.
 RS_VERSION = "1.38.0"
-
-RUSTC_SNAPSHOT = "rustc-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
-RUST_STD_SNAPSHOT = "rust-std-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
 CARGO_VERSION = "0.39.0"
-CARGO_SNAPSHOT = "cargo-${CARGO_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
-
-SRC_URI += " \
-	https://static.rust-lang.org/dist/${RUSTC_SNAPSHOT}.tar.xz;name=rustc-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	https://static.rust-lang.org/dist/${RUST_STD_SNAPSHOT}.tar.xz;name=rust-std-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	https://static.rust-lang.org/dist/${CARGO_SNAPSHOT}.tar.xz;name=cargo-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	"
 
 # TODO: Add hashes for other architecture toolchains as well. Make a script?
 SRC_URI[rustc-snapshot-x86_64.md5sum] = "53278262a3996982cd68730db7cb1efd"

--- a/recipes-devtools/rust/rust-snapshot-1.39.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.39.0.inc
@@ -8,9 +8,6 @@ RS_VERSION = "1.38.0"
 CARGO_VERSION = "0.39.0"
 
 # TODO: Add hashes for other architecture toolchains as well. Make a script?
-SRC_URI[rustc-snapshot-x86_64.md5sum] = "53278262a3996982cd68730db7cb1efd"
 SRC_URI[rustc-snapshot-x86_64.sha256sum] = "0fedde3406cf3367ceb00f493698e6bfc3264bd7f7253c85de7a042b45f873fa"
-SRC_URI[rust-std-snapshot-x86_64.md5sum] = "0d32b76359613f73671acd13ea57b7ea"
 SRC_URI[rust-std-snapshot-x86_64.sha256sum] = "51b334337804baeff7524e5496d396f254894d7529860d236975e9ed8fcca371"
-SRC_URI[cargo-snapshot-x86_64.md5sum] = "7274cfe12905fe8ea6edbe131d3f6637"
 SRC_URI[cargo-snapshot-x86_64.sha256sum] = "80bcb1368ce98d13cb371df89cbbed9007fb98843f34d07f2abd2c03b8f2747a"

--- a/recipes-devtools/rust/rust-snapshot-1.40.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.40.0.inc
@@ -8,9 +8,6 @@ RS_VERSION = "1.39.0"
 CARGO_VERSION = "0.40.0"
 
 # TODO: Add hashes for other architecture toolchains as well. Make a script?
-SRC_URI[rustc-snapshot-x86_64.md5sum] = "aa10585498675e44be219d3644c15853"
 SRC_URI[rustc-snapshot-x86_64.sha256sum] = "5b2a435a4c034615d70cfc383abe9924cbd1ffd4669caa55ce6539f22ed979ed"
-SRC_URI[rust-std-snapshot-x86_64.md5sum] = "d8b8e6f1a5a255d22b9f86c97a65049f"
 SRC_URI[rust-std-snapshot-x86_64.sha256sum] = "b629952ec9e3e750137d7b8a922de145c97c1dc372dd616e86e4e501da13910b"
-SRC_URI[cargo-snapshot-x86_64.md5sum] = "a51643b8980bcaefa9043715a8e9a2ba"
 SRC_URI[cargo-snapshot-x86_64.sha256sum] = "7b9ba52c252964724f49aab49e42bec62fca929297ef058412c7e727b0794620"

--- a/recipes-devtools/rust/rust-snapshot-1.40.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.40.0.inc
@@ -1,19 +1,11 @@
+require rust-snapshot.inc
+
 ## This is information on the rust-snapshot (binary) used to build our current release.
 ## snapshot info is taken from rust/src/stage0.txt
 ## TODO: find a way to add additional SRC_URIs based on the contents of an
 ##       earlier SRC_URI.
 RS_VERSION = "1.39.0"
-
-RUSTC_SNAPSHOT = "rustc-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
-RUST_STD_SNAPSHOT = "rust-std-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
 CARGO_VERSION = "0.40.0"
-CARGO_SNAPSHOT = "cargo-${CARGO_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
-
-SRC_URI += " \
-	https://static.rust-lang.org/dist/${RUSTC_SNAPSHOT}.tar.xz;name=rustc-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	https://static.rust-lang.org/dist/${RUST_STD_SNAPSHOT}.tar.xz;name=rust-std-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	https://static.rust-lang.org/dist/${CARGO_SNAPSHOT}.tar.xz;name=cargo-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	"
 
 # TODO: Add hashes for other architecture toolchains as well. Make a script?
 SRC_URI[rustc-snapshot-x86_64.md5sum] = "aa10585498675e44be219d3644c15853"

--- a/recipes-devtools/rust/rust-snapshot-1.41.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.41.0.inc
@@ -1,19 +1,11 @@
+require rust-snapshot.inc
+
 ## This is information on the rust-snapshot (binary) used to build our current release.
 ## snapshot info is taken from rust/src/stage0.txt
 ## TODO: find a way to add additional SRC_URIs based on the contents of an
 ##       earlier SRC_URI.
 RS_VERSION = "1.40.0"
-
-RUSTC_SNAPSHOT = "rustc-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
-RUST_STD_SNAPSHOT = "rust-std-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
 CARGO_VERSION = "0.41.0"
-CARGO_SNAPSHOT = "cargo-${CARGO_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
-
-SRC_URI += " \
-	https://static.rust-lang.org/dist/${RUSTC_SNAPSHOT}.tar.xz;name=rustc-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	https://static.rust-lang.org/dist/${RUST_STD_SNAPSHOT}.tar.xz;name=rust-std-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	https://static.rust-lang.org/dist/${CARGO_SNAPSHOT}.tar.xz;name=cargo-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	"
 
 # TODO: Add hashes for other architecture toolchains as well. Make a script?
 SRC_URI[rustc-snapshot-x86_64.md5sum] = "5c62bca8ce4beb9b15e42fb8b9690935"

--- a/recipes-devtools/rust/rust-snapshot-1.41.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.41.0.inc
@@ -8,9 +8,6 @@ RS_VERSION = "1.40.0"
 CARGO_VERSION = "0.41.0"
 
 # TODO: Add hashes for other architecture toolchains as well. Make a script?
-SRC_URI[rustc-snapshot-x86_64.md5sum] = "5c62bca8ce4beb9b15e42fb8b9690935"
 SRC_URI[rustc-snapshot-x86_64.sha256sum] = "b1c00618b7a98156e88b14682508a503284f85748eab23de749a20dcc8847111"
-SRC_URI[rust-std-snapshot-x86_64.md5sum] = "2f926b4eda6449079665045becff623d"
 SRC_URI[rust-std-snapshot-x86_64.sha256sum] = "5a0b14a51f51b0194f70a2023749d9cb49c3b2e11f0d4c8232960b91fad336ac"
-SRC_URI[cargo-snapshot-x86_64.md5sum] = "8ea9f8b849d44abf2abf9180f90cc4b6"
 SRC_URI[cargo-snapshot-x86_64.sha256sum] = "9b6ae643fa240c5ecbc1dc390f4020b6a683f25bac6f7437ebd4b9d32a8d0b6c"

--- a/recipes-devtools/rust/rust-snapshot-1.43.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.43.0.inc
@@ -1,19 +1,11 @@
+require rust-snapshot.inc
+
 ## This is information on the rust-snapshot (binary) used to build our current release.
 ## snapshot info is taken from rust/src/stage0.txt
 ## TODO: find a way to add additional SRC_URIs based on the contents of an
 ##       earlier SRC_URI.
 RS_VERSION = "1.43.1"
-
-RUSTC_SNAPSHOT = "rustc-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
-RUST_STD_SNAPSHOT = "rust-std-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
 CARGO_VERSION = "0.43.0"
-CARGO_SNAPSHOT = "cargo-${CARGO_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
-
-SRC_URI += " \
-	https://static.rust-lang.org/dist/${RUSTC_SNAPSHOT}.tar.xz;name=rustc-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	https://static.rust-lang.org/dist/${RUST_STD_SNAPSHOT}.tar.xz;name=rust-std-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	https://static.rust-lang.org/dist/${CARGO_SNAPSHOT}.tar.xz;name=cargo-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	"
 
 # TODO: Add hashes for other architecture toolchains as well. Make a script?
 SRC_URI[rustc-snapshot-x86_64.sha256sum] = "a18b89572ff2e55eb9e0428efcdb60eacd82fe28c4d825d169b0ffc9e3c55ceb"

--- a/recipes-devtools/rust/rust-snapshot-1.46.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.46.0.inc
@@ -8,9 +8,6 @@ RS_VERSION = "1.45.2"
 CARGO_VERSION = "0.46.1"
 
 # TODO: Add hashes for other architecture toolchains as well. Make a script?
-SRC_URI[rust-std-snapshot-x86_64.md5sum] = "cb78b0da8ded02b9b80b58d608b58ef8"
 SRC_URI[rust-std-snapshot-x86_64.sha256sum] = "02309322467af8e37256ccf1f064f5233c7fca4423dffde0bd5eb32cde46942a"
-SRC_URI[rustc-snapshot-x86_64.md5sum] = "e32ae176d4f35935ffe39b477a3ded2a"
 SRC_URI[rustc-snapshot-x86_64.sha256sum] = "0be5c8506fd9317c7d0dc8044b5fef8501caa74f88a9a22be795d68362dc57f6"
-SRC_URI[cargo-snapshot-x86_64.md5sum] = "89f06274bbd387d7e7f5476011a61f34"
 SRC_URI[cargo-snapshot-x86_64.sha256sum] = "a27eb5d47b520ef2c554605bf789f80652af63531b4f6a1195d61b3dfd0f6e9c"

--- a/recipes-devtools/rust/rust-snapshot-1.46.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.46.0.inc
@@ -1,19 +1,11 @@
+require rust-snapshot.inc
+
 ## This is information on the rust-snapshot (binary) used to build our current release.
 ## snapshot info is taken from rust/src/stage0.txt
 ## TODO: find a way to add additional SRC_URIs based on the contents of an
 ##       earlier SRC_URI.
 RS_VERSION = "1.45.2"
-
-RUSTC_SNAPSHOT = "rustc-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
-RUST_STD_SNAPSHOT = "rust-std-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
 CARGO_VERSION = "0.46.1"
-CARGO_SNAPSHOT = "cargo-${CARGO_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
-
-SRC_URI += " \
-	https://static.rust-lang.org/dist/${RUSTC_SNAPSHOT}.tar.xz;name=rustc-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	https://static.rust-lang.org/dist/${RUST_STD_SNAPSHOT}.tar.xz;name=rust-std-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	https://static.rust-lang.org/dist/${CARGO_SNAPSHOT}.tar.xz;name=cargo-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	"
 
 # TODO: Add hashes for other architecture toolchains as well. Make a script?
 SRC_URI[rust-std-snapshot-x86_64.md5sum] = "cb78b0da8ded02b9b80b58d608b58ef8"

--- a/recipes-devtools/rust/rust-snapshot-1.47.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.47.0.inc
@@ -1,19 +1,11 @@
+require rust-snapshot.inc
+
 ## This is information on the rust-snapshot (binary) used to build our current release.
 ## snapshot info is taken from rust/src/stage0.txt
 ## TODO: find a way to add additional SRC_URIs based on the contents of an
 ##       earlier SRC_URI.
 RS_VERSION = "1.46.0"
-
-RUSTC_SNAPSHOT = "rustc-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
-RUST_STD_SNAPSHOT = "rust-std-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
 CARGO_VERSION = "0.47.0"
-CARGO_SNAPSHOT = "cargo-${CARGO_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
-
-SRC_URI += " \
-	https://static.rust-lang.org/dist/${RUSTC_SNAPSHOT}.tar.xz;name=rustc-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	https://static.rust-lang.org/dist/${RUST_STD_SNAPSHOT}.tar.xz;name=rust-std-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	https://static.rust-lang.org/dist/${CARGO_SNAPSHOT}.tar.xz;name=cargo-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
-	"
 
 # TODO: Add hashes for other architecture toolchains as well. Make a script?
 SRC_URI[rust-std-snapshot-x86_64.sha256sum] = "e631d80cb03539769c041ee4566e94e36a271d4b3cdd149e1447d1f77fda979c"

--- a/recipes-devtools/rust/rust-snapshot.inc
+++ b/recipes-devtools/rust/rust-snapshot.inc
@@ -1,0 +1,9 @@
+SRC_URI += " \
+    https://static.rust-lang.org/dist/${RUST_STD_SNAPSHOT}.tar.xz;name=rust-std-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
+    https://static.rust-lang.org/dist/${RUSTC_SNAPSHOT}.tar.xz;name=rustc-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
+    https://static.rust-lang.org/dist/${CARGO_SNAPSHOT}.tar.xz;name=cargo-snapshot-${BUILD_ARCH};subdir=rust-snapshot-components \
+"
+
+RUST_STD_SNAPSHOT = "rust-std-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
+RUSTC_SNAPSHOT = "rustc-${RS_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"
+CARGO_SNAPSHOT = "cargo-${CARGO_VERSION}-${BUILD_ARCH}-unknown-linux-gnu"

--- a/recipes-devtools/rust/rust-source-1.34.2.inc
+++ b/recipes-devtools/rust/rust-source-1.34.2.inc
@@ -1,4 +1,3 @@
 require rust-source.inc
 
-SRC_URI[rust.md5sum] = "2f3b962aba2eefd105e7df074ef9e99e"
 SRC_URI[rust.sha256sum] = "2b3b3a5462aa31d07f39721af73ef394803ceae3472e2470f28b7ee0b12e38ef"

--- a/recipes-devtools/rust/rust-source-1.34.2.inc
+++ b/recipes-devtools/rust/rust-source-1.34.2.inc
@@ -1,9 +1,4 @@
-SRC_URI += "https://static.rust-lang.org/dist/rustc-${PV}-src.tar.gz;name=rust"
+require rust-source.inc
 
-SRC_URI[rust.md5sum] = "7c85e6a60dda740295f7e004a1fb15e1"
-SRC_URI[rust.sha256sum] = "c69a4a85a1c464368597df8878cb9e1121aae93e215616d45ad7d23af3052f56"
-
-# later versions of rust change the directory that they unextract to
-RUSTSRC = "${WORKDIR}/rustc-${PV}-src"
-# set this as our default
-S = "${RUSTSRC}"
+SRC_URI[rust.md5sum] = "2f3b962aba2eefd105e7df074ef9e99e"
+SRC_URI[rust.sha256sum] = "2b3b3a5462aa31d07f39721af73ef394803ceae3472e2470f28b7ee0b12e38ef"

--- a/recipes-devtools/rust/rust-source-1.36.0.inc
+++ b/recipes-devtools/rust/rust-source-1.36.0.inc
@@ -1,4 +1,3 @@
 require rust-source.inc
 
-SRC_URI[rust.md5sum] = "78ffc0b029aaed216b45c3fe24747d46"
 SRC_URI[rust.sha256sum] = "f51645b9f787af4a5d94db17f6af39db0c55980ed24fe366cad55b57900f8f2d"

--- a/recipes-devtools/rust/rust-source-1.36.0.inc
+++ b/recipes-devtools/rust/rust-source-1.36.0.inc
@@ -1,9 +1,4 @@
-SRC_URI += "https://static.rust-lang.org/dist/rustc-${PV}-src.tar.xz;name=rust"
+require rust-source.inc
 
 SRC_URI[rust.md5sum] = "78ffc0b029aaed216b45c3fe24747d46"
 SRC_URI[rust.sha256sum] = "f51645b9f787af4a5d94db17f6af39db0c55980ed24fe366cad55b57900f8f2d"
-
-# later versions of rust change the directory that they unextract to
-RUSTSRC = "${WORKDIR}/rustc-${PV}-src"
-# set this as our default
-S = "${RUSTSRC}"

--- a/recipes-devtools/rust/rust-source-1.37.0.inc
+++ b/recipes-devtools/rust/rust-source-1.37.0.inc
@@ -1,9 +1,4 @@
-SRC_URI += "https://static.rust-lang.org/dist/rustc-${PV}-src.tar.xz;name=rust"
+require rust-source.inc
 
 SRC_URI[rust.md5sum] = "ee6300b1d7e5767115492915c4c0d8ef"
 SRC_URI[rust.sha256sum] = "10abffac50a729cf74cef6dd03193a2f4647541bd19ee9281be9e5b12ca8cdfd"
-
-# later versions of rust change the directory that they unextract to
-RUSTSRC = "${WORKDIR}/rustc-${PV}-src"
-# set this as our default
-S = "${RUSTSRC}"

--- a/recipes-devtools/rust/rust-source-1.37.0.inc
+++ b/recipes-devtools/rust/rust-source-1.37.0.inc
@@ -1,4 +1,3 @@
 require rust-source.inc
 
-SRC_URI[rust.md5sum] = "ee6300b1d7e5767115492915c4c0d8ef"
 SRC_URI[rust.sha256sum] = "10abffac50a729cf74cef6dd03193a2f4647541bd19ee9281be9e5b12ca8cdfd"

--- a/recipes-devtools/rust/rust-source-1.39.0.inc
+++ b/recipes-devtools/rust/rust-source-1.39.0.inc
@@ -1,4 +1,3 @@
 require rust-source.inc
 
-SRC_URI[rust.md5sum] = "ee76b165cd95ef420765bfb568adb450"
 SRC_URI[rust.sha256sum] = "4b0dbb356070687a606034f71dc032b783bbf8b5d3f9fff39f2c1fbc4f171c29"

--- a/recipes-devtools/rust/rust-source-1.39.0.inc
+++ b/recipes-devtools/rust/rust-source-1.39.0.inc
@@ -1,9 +1,4 @@
-SRC_URI += "https://static.rust-lang.org/dist/rustc-${PV}-src.tar.xz;name=rust"
+require rust-source.inc
 
 SRC_URI[rust.md5sum] = "ee76b165cd95ef420765bfb568adb450"
 SRC_URI[rust.sha256sum] = "4b0dbb356070687a606034f71dc032b783bbf8b5d3f9fff39f2c1fbc4f171c29"
-
-# later versions of rust change the directory that they unextract to
-RUSTSRC = "${WORKDIR}/rustc-${PV}-src"
-# set this as our default
-S = "${RUSTSRC}"

--- a/recipes-devtools/rust/rust-source-1.40.0.inc
+++ b/recipes-devtools/rust/rust-source-1.40.0.inc
@@ -1,4 +1,3 @@
 require rust-source.inc
 
-SRC_URI[rust.md5sum] = "1725f67a1d92ab843a71fbbefef06db9"
 SRC_URI[rust.sha256sum] = "6e2aa3a91697f4b225c6b394cbae6b97666f061dba491f666a5281698fe2aace"

--- a/recipes-devtools/rust/rust-source-1.40.0.inc
+++ b/recipes-devtools/rust/rust-source-1.40.0.inc
@@ -1,9 +1,4 @@
-SRC_URI += "https://static.rust-lang.org/dist/rustc-${PV}-src.tar.xz;name=rust"
+require rust-source.inc
 
 SRC_URI[rust.md5sum] = "1725f67a1d92ab843a71fbbefef06db9"
 SRC_URI[rust.sha256sum] = "6e2aa3a91697f4b225c6b394cbae6b97666f061dba491f666a5281698fe2aace"
-
-# later versions of rust change the directory that they unextract to
-RUSTSRC = "${WORKDIR}/rustc-${PV}-src"
-# set this as our default
-S = "${RUSTSRC}"

--- a/recipes-devtools/rust/rust-source-1.41.0.inc
+++ b/recipes-devtools/rust/rust-source-1.41.0.inc
@@ -1,4 +1,3 @@
 require rust-source.inc
 
-SRC_URI[rust.md5sum] = "e8c9d1d39ceb0dd43ee0100d0f019da4"
 SRC_URI[rust.sha256sum] = "38d6742e5c4c98a835de5d6e12a209e442fb3078a03b2c01bab6ea7afb25be6f"

--- a/recipes-devtools/rust/rust-source-1.41.0.inc
+++ b/recipes-devtools/rust/rust-source-1.41.0.inc
@@ -1,9 +1,4 @@
-SRC_URI += "https://static.rust-lang.org/dist/rustc-${PV}-src.tar.xz;name=rust"
+require rust-source.inc
 
 SRC_URI[rust.md5sum] = "e8c9d1d39ceb0dd43ee0100d0f019da4"
 SRC_URI[rust.sha256sum] = "38d6742e5c4c98a835de5d6e12a209e442fb3078a03b2c01bab6ea7afb25be6f"
-
-# later versions of rust change the directory that they unextract to
-RUSTSRC = "${WORKDIR}/rustc-${PV}-src"
-# set this as our default
-S = "${RUSTSRC}"

--- a/recipes-devtools/rust/rust-source-1.43.0.inc
+++ b/recipes-devtools/rust/rust-source-1.43.0.inc
@@ -1,8 +1,3 @@
-SRC_URI += "https://static.rust-lang.org/dist/rustc-${PV}-src.tar.xz;name=rust"
+require rust-source.inc
 
 SRC_URI[rust.sha256sum] = "d0899933840369f07394b211cb0b53a5cd4634907633f0bee541133c8b75e309"
-
-# later versions of rust change the directory that they unextract to
-RUSTSRC = "${WORKDIR}/rustc-${PV}-src"
-# set this as our default
-S = "${RUSTSRC}"

--- a/recipes-devtools/rust/rust-source-1.46.0.inc
+++ b/recipes-devtools/rust/rust-source-1.46.0.inc
@@ -1,9 +1,4 @@
-SRC_URI += "https://static.rust-lang.org/dist/rustc-${PV}-src.tar.xz;name=rust"
+require rust-source.inc
 
 SRC_URI[rust.md5sum] = "4e3a58429c20e45385e592b0975698dc"
 SRC_URI[rust.sha256sum] = "865dae1290a205f16ded8818c6a0254cc32862985fc250a602a70285b7d92b82"
-
-# later versions of rust change the directory that they unextract to
-RUSTSRC = "${WORKDIR}/rustc-${PV}-src"
-# set this as our default
-S = "${RUSTSRC}"

--- a/recipes-devtools/rust/rust-source-1.46.0.inc
+++ b/recipes-devtools/rust/rust-source-1.46.0.inc
@@ -1,4 +1,3 @@
 require rust-source.inc
 
-SRC_URI[rust.md5sum] = "4e3a58429c20e45385e592b0975698dc"
 SRC_URI[rust.sha256sum] = "865dae1290a205f16ded8818c6a0254cc32862985fc250a602a70285b7d92b82"

--- a/recipes-devtools/rust/rust-source-1.47.0.inc
+++ b/recipes-devtools/rust/rust-source-1.47.0.inc
@@ -1,8 +1,3 @@
-SRC_URI += "https://static.rust-lang.org/dist/rustc-${PV}-src.tar.xz;name=rust"
+require rust-source.inc
 
 SRC_URI[rust.sha256sum] = "ec2c81d2d34890486094a6407589be96161e4e301c238332d32c6dbae4f38ea2"
-
-# later versions of rust change the directory that they unextract to
-RUSTSRC = "${WORKDIR}/rustc-${PV}-src"
-# set this as our default
-S = "${RUSTSRC}"

--- a/recipes-devtools/rust/rust-source.inc
+++ b/recipes-devtools/rust/rust-source.inc
@@ -1,0 +1,3 @@
+SRC_URI += "https://static.rust-lang.org/dist/rustc-${PV}-src.tar.xz;name=rust"
+
+RUSTSRC = "${WORKDIR}/rustc-${PV}-src"

--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -10,6 +10,8 @@ inherit cargo_common
 DEPENDS += "file-native python3-native"
 DEPENDS_append_class-native = " rust-llvm-native"
 
+S = "${RUSTSRC}"
+
 # We generate local targets, and need to be able to locate them
 export RUST_TARGET_PATH="${WORKDIR}/targets/"
 


### PR DESCRIPTION
I've also updated https://github.com/meta-rust/meta-rust/pull/293 with these (and previous) cleanups, it's in jansa/lic-1.49.0 branch (see https://github.com/meta-rust/meta-rust/compare/master...shr-project:jansa/lic-1.49.0?expand=1)