### PR TITLE
Fix *-native cargo builds

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -9,7 +9,7 @@ inherit cargo_common
 CARGO = "cargo"
 
 # We need cargo to compile for the target
-BASEDEPENDS_append_class-target = " cargo-native"
+BASEDEPENDS_append = " cargo-native"
 
 # Ensure we get the right rust variant
 DEPENDS_append_class-target = " virtual/${TARGET_PREFIX}rust ${RUSTLIB_DEP}"

--- a/recipes-devtools/cargo/cargo.inc
+++ b/recipes-devtools/cargo/cargo.inc
@@ -45,6 +45,7 @@ export LIBSSH2_SYS_USE_PKG_CONFIG = "1"
 
 BBCLASSEXTEND = "native"
 
-# When building cargo-native we don't have a built cargo to use so we must use
-# the snapshot to bootstrap the build of cargo
+# When building cargo-native we don't have cargo-native to use and depend on,
+# so we must use the locally set up snapshot to bootstrap the build.
+BASEDEPENDS_remove_class-native = "cargo-native"
 CARGO_class-native = "${WORKDIR}/${CARGO_SNAPSHOT}/bin/cargo"


### PR DESCRIPTION
Normally all *-native packages needs to depend on cargo-native in order
to be able to use cargo. When building cargo-native however, this is not
available and we use a snapshot.

Fixes #302.