### PR TITLE
rust: Drop v8.1a tune for aarch64

### DIFF
--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -66,9 +66,6 @@ def llvm_features_from_tune(d):
     if 'neon' in feat:
         f.append("+neon")
 
-    if 'aarch64' in feat:
-        f.append("+v8.1a")
-
     if 'mips32' in feat:
         f.append("+mips32")
 


### PR DESCRIPTION
Building for "+v8.1a"  breaks on (at least) Cortex A53 (Armv8-A) on startup with `Illegal instruction`.

Fixes: 26609f46d93c ("rust.inc: use 'v8.1a' feature when building for aarch64 instead of 'v8'")