### PR TITLE
Factor in `CARGO_SRC_DIR` when setting `MANIFEST_PATH`.

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -22,8 +22,12 @@ B = "${WORKDIR}/build"
 # where the issue occured
 export RUST_BACKTRACE = "1"
 
-# Assume there's a Cargo.toml directly in the source directory
-MANIFEST_PATH ??= "${S}/Cargo.toml"
+# The directory of the Cargo.toml relative to the root directory, per default
+# assume there's a Cargo.toml directly in the root directory
+CARGO_SRC_DIR ??= ""
+
+# The actual path to the Cargo.toml
+MANIFEST_PATH ??= "${S}/${CARGO_SRC_DIR}/Cargo.toml"
 
 RUSTFLAGS ??= ""
 BUILD_MODE = "${@['--release', ''][d.getVar('DEBUG_BUILD') == '1']}"


### PR DESCRIPTION
Fixes Cargo workspace builds, see #309 . There is an alternative PR up within `cargo-bitbake` https://github.com/meta-rust/cargo-bitbake/pull/23.