### PR TITLE
rust-native shouldn't depend on TARGET variables

### DIFF
--- a/recipes-devtools/rust/rust-cross.inc
+++ b/recipes-devtools/rust/rust-cross.inc
@@ -10,10 +10,14 @@ python do_rust_gen_targets () {
         bb.debug(1, "rust_gen_target for " + thing)
         features = ""
         cpu = "generic"
+        arch = d.getVar('{}_ARCH'.format(thing))
         if thing is "TARGET":
+            # arm and armv7 have different targets in llvm
+            if arch == "arm" and target_is_armv7(d):
+                arch = 'armv7'
             features = d.getVar('TARGET_LLVM_FEATURES') or ""
             cpu = d.getVar('TARGET_LLVM_CPU')
-        rust_gen_target(d, thing, wd, features, cpu)
+        rust_gen_target(d, thing, wd, features, cpu, arch)
 }
 
 # Otherwise we'll depend on what we provide

--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -252,12 +252,6 @@ TARGET_POINTER_WIDTH[riscv64] = "64"
 TARGET_C_INT_WIDTH[riscv64] = "64"
 MAX_ATOMIC_WIDTH[riscv64] = "64"
 
-def arch_for(d, thing):
-    if thing == 'TARGET' and target_is_armv7(d):
-        return "armv7"
-    else:
-        return d.getVar('{}_ARCH'.format(thing))
-
 def sys_for(d, thing):
     return d.getVar('{}_SYS'.format(thing))
 
@@ -316,10 +310,9 @@ TARGET_LLVM_FEATURES = "${@llvm_features(d)}"
 # (original) target.
 TARGET_LLVM_FEATURES_class-native = "${@','.join(llvm_features_from_cc_arch(d))}"
 
-def rust_gen_target(d, thing, wd, features, cpu):
+def rust_gen_target(d, thing, wd, features, cpu, arch):
     import json
     from distutils.version import LooseVersion
-    arch = arch_for(d, thing)
     sys = sys_for(d, thing)
     prefix = prefix_for(d, thing)
 
@@ -373,7 +366,8 @@ def rust_gen_target(d, thing, wd, features, cpu):
 
 python do_rust_gen_targets () {
     wd = d.getVar('WORKDIR') + '/targets/'
-    rust_gen_target(d, 'BUILD', wd, "", "generic")
+    build_arch = d.getVar('BUILD_ARCH')
+    rust_gen_target(d, 'BUILD', wd, "", "generic", build_arch)
 }
 
 addtask rust_gen_targets after do_patch before do_compile


### PR DESCRIPTION
Similar to 3b783652cc9e0e0ff95fdf151eab3e178b5f1667, this makes sure
rust-native does not depend on target variables. This allow one
rust-native to be shared between machines of different architectures
again.

For the record, the following guide was used to find out why
do_rust_gen_targets differed between different machines.
https://wiki.yoctoproject.org/wiki/TipsAndTricks/Understanding_what_changed_(diffsigs_etc)