### PR TITLE
Revamp llvm_cpu to select the closest CPU for optimization.

### DIFF
--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -296,8 +296,6 @@ def llvm_cpu(d):
     trans = {}
     trans['i586'] = "i586"
     trans['i686'] = "i686"
-    trans['mips'] = "mips32"
-    trans['mipsel'] = "mips32"
     trans['mips64'] = "mips64"
     trans['mips64el'] = "mips64"
     trans['powerpc'] = "ppc"

--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -274,34 +274,46 @@ def arch_to_rust_target_arch(arch):
 
 # generates our target CPU value
 def llvm_cpu(d):
-    cpu = d.getVar('PACKAGE_ARCH')
-    target = d.getVar('TRANSLATED_TARGET_ARCH')
-
+    # First check if TUNE_CCARGS gives us a specific CPU to build for (via -march).
+    # Translate that GCC -march flag to a Rust/LLVM CPU.
     trans = {}
-    trans['corei7-64'] = "corei7"
-    trans['core2-32'] = "core2"
-    trans['x86-64'] = "x86-64"
-    trans['i686'] = "i686"
+    trans['btver2'] = "btver2"
+    trans['core2'] = "core2"
+    trans['mips32'] = "mips32"
+    trans['mips32r2'] = "mips32r2"
+    trans['nehalem'] = "nehalem"
+    trans['skylake'] = "skylake"
+
+    for arg in (d.getVar('TUNE_CCARGS') or '').split():
+        if arg.startswith('-march='):
+            march = arg[7:]
+            cpu = trans.get(march)
+            if cpu:
+                return cpu
+
+    # If we don't have -march in TUNE_CCARGS, check TRANSLATED_TARGET_ARCH.
+    # This must also be translated into a Rust/LLVM CPU.
+    trans = {}
     trans['i586'] = "i586"
-    trans['powerpc'] = "powerpc"
+    trans['i686'] = "i686"
+    trans['mips'] = "mips32"
+    trans['mipsel'] = "mips32"
     trans['mips64'] = "mips64"
     trans['mips64el'] = "mips64"
-    trans['riscv64'] = "generic-rv64"
+    trans['powerpc'] = "ppc"
+    trans['powerpc64'] = "ppc64"
     trans['riscv32'] = "generic-rv32"
+    trans['riscv64'] = "generic-rv64"
+    trans['x86-64'] = "x86-64"
 
-    if target in ["mips", "mipsel"]:
-        feat = frozenset(d.getVar('TUNE_FEATURES').split())
-        if "mips32r2" in feat:
-            trans['mipsel'] = "mips32r2"
-            trans['mips'] = "mips32r2"
-        elif "mips32" in feat:
-            trans['mipsel'] = "mips32"
-            trans['mips'] = "mips32"
+    target = d.getVar('TRANSLATED_TARGET_ARCH')
+    cpu = trans.get(target)
+    if cpu:
+        return cpu
 
-    try:
-        return trans[cpu]
-    except:
-        return trans.get(target, "generic")
+    # If we still didn't get a target CPU, choose "generic".
+    # Further optimization can still happen via llvm_features.
+    return "generic"
 
 TARGET_LLVM_CPU="${@llvm_cpu(d)}"
 TARGET_LLVM_FEATURES = "${@llvm_features(d)}"


### PR DESCRIPTION
This function has a long history, which is worth telling:
* It was added in https://github.com/meta-rust/meta-rust/commit/ba16b5c39e3a23452a98a88d1ca58da0448f97f0 with the same idea: Optimize for 32-bit Core2 or 64-bit Core i7 if possible, otherwise select the closest generic x86 CPU, otherwise select a completely generic CPU. This implementation had two flaws:
    * It used a single translation table for two variables (`TUNE_PKGARCH` and `TRANSLATED_TARGET_ARCH`), making it hard to guess where a certain value comes from and whether one is still needed.
    * It used `TUNE_PKGARCH`, which is an arbitrary CPU description that everyone can make up with an own machine definition. Hence, this list can never be complete.
* `TUNE_PKGARCH` was replaced by `PACKAGE_ARCH` in https://github.com/meta-rust/meta-rust/commit/97fcc5db567e16e15a16b7b0ed5707ebc480d97e to "ensure older processors can run created executables when building targets that have newer features". In my opinion, this change made no sense at all:
    * If you choose e.g. "corei7-64" as your target, Yocto will obviously build all applications for Core i7 and later only. People are supposed to select a generic target if they want generic applications that can run on old and new processors.
    * `TUNE_PKGARCH` is no longer checked, but the translation table kept its entries for "core2-32" and "corei7-64". These cases just cannot happen anymore.
* MIPS support was added in https://github.com/meta-rust/meta-rust/commit/f02df59eea737b1ee0e35db213e27201c5427622 and now evaluates a third variable `TUNE_FEATURES` to decide on the CPU.
* PowerPC support was added in https://github.com/meta-rust/meta-rust/commit/68d6bce6091621f738ad1ef75af7dcebe4df5d35, but it translates "powerpc" to "powerpc" instead of "ppc" (which is the correct Rust/LLVM internal CPU name).

My PR now changes `llvm_cpu` to first evaluate the `TUNE_CCARGS` variable. Every machine definition that wants to optimize for a particular CPU puts a `-march` flag for GCC here. My code translates this to a Rust/LLVM CPU definition (1:1 mappings so far, but this is not guaranteed!).
This covers machines defined in the meta-pcengines layer ("pcengines-apu2" sets `-march=btver2`), the meta-intel layer ("core2-32" sets `-march=core2`, "corei7-64" sets `-march=nehalem`, "skylake-64" sets `-march=skylake`), and it should cover the MIPS cases that were previously handled via the `TUNE_FEATURES` variable.
Note that this list still needs to be maintained, but `-march` flags are standardized whereas machine names are arbitrary.

If no match has been found for the `-march` flag, I check the `TRANSLATED_TARGET_ARCH` variable and return a generic CPU for that architecture. This covers remaining x86 and MIPS cases where no specific CPU is set, and also fixes the previously wrong PowerPC CPU name.

If no match has been found for `TRANSLATED_TARGET_ARCH` either, I return "generic". This is the case for e.g. ARM where optimization has been entirely implemented via feature flags.
