### PR TITLE
rust-llvm: Fix build with gcc11

### DIFF
--- a/recipes-devtools/rust/rust-llvm.inc
+++ b/recipes-devtools/rust/rust-llvm.inc
@@ -1,7 +1,9 @@
 SUMMARY = "LLVM compiler framework (packaged with rust)"
 LICENSE ?= "Apache-2.0-with-LLVM-exception"
 
-SRC_URI += "file://0002-llvm-allow-env-override-of-exe-path.patch"
+SRC_URI += "file://0001-nfc-Fix-missing-include.patch;striplevel=2 \
+            file://0002-llvm-allow-env-override-of-exe-path.patch;striplevel=2 \
+            "
 
 S = "${RUSTSRC}/src/llvm-project/llvm"
 

--- a/recipes-devtools/rust/rust-llvm/0001-nfc-Fix-missing-include.patch
+++ b/recipes-devtools/rust/rust-llvm/0001-nfc-Fix-missing-include.patch
@@ -1,0 +1,26 @@
+From 3b7e611bd58ba842470d17374c550e14bceca5c7 Mon Sep 17 00:00:00 2001
+From: serge-sans-paille <sguelton@redhat.com>
+Date: Tue, 10 Nov 2020 14:55:25 +0100
+Subject: [PATCH] [nfc] Fix missing include
+
+Upstream-Status: Backport [https://github.com/llvm/llvm-project/commit/b498303066a63a203d24f739b2d2e0e56dca70d1]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ llvm/utils/benchmark/src/benchmark_register.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/llvm/utils/benchmark/src/benchmark_register.h b/llvm/utils/benchmark/src/benchmark_register.h
+index 0705e219f2fa..4caa5ad4da07 100644
+--- a/llvm/utils/benchmark/src/benchmark_register.h
++++ b/llvm/utils/benchmark/src/benchmark_register.h
+@@ -1,6 +1,7 @@
+ #ifndef BENCHMARK_REGISTER_H
+ #define BENCHMARK_REGISTER_H
+ 
++#include <limits>
+ #include <vector>
+ 
+ #include "check.h"
+-- 
+2.30.1
+

--- a/recipes-devtools/rust/rust-llvm/0002-llvm-allow-env-override-of-exe-path.patch
+++ b/recipes-devtools/rust/rust-llvm/0002-llvm-allow-env-override-of-exe-path.patch
@@ -11,11 +11,11 @@ llvm-config from a target sysroot.
 Signed-off-by: Martin Kelly <mkelly@xevo.com>
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
 ---
- tools/llvm-config/llvm-config.cpp | 7 +++++++
+ llvm/tools/llvm-config/llvm-config.cpp | 7 +++++++
  1 file changed, 7 insertions(+)
 
---- a/tools/llvm-config/llvm-config.cpp
-+++ b/tools/llvm-config/llvm-config.cpp
+--- a/llvm/tools/llvm-config/llvm-config.cpp
++++ b/llvm/tools/llvm-config/llvm-config.cpp
 @@ -226,6 +226,13 @@ Typical components:\n\
  
  /// Compute the path to the main executable.


### PR DESCRIPTION
Backport a patch from upstream llvm

Fixes build errors like
```
| /mnt/b/yoe/master/build/tmp/work/riscv64-yoe-linux/rust-llvm/1.49.0-r0/rustc-1.49.0-src/src/llvm-project/llvm/utils/ben
chmark/src/benchmark_register.h: In function 'void AddRange(std::vector<T>*, T, T, int)':
| /mnt/b/yoe/master/build/tmp/work/riscv64-yoe-linux/rust-llvm/1.49.0-r0/rustc-1.49.0-src/src/llvm-project/llvm/utils/ben
chmark/src/benchmark_register.h:17:30: error: 'numeric_limits' is not a member of 'std'
|    17 |   static const T kmax = std::numeric_limits<T>::max();
|       |                              ^~~~~~~~~~~~~~
| /mnt/b/yoe/master/build/tmp/work/riscv64-yoe-linux/rust-llvm/1.49.0-r0/rustc-1.49.0-src/src/llvm-project/llvm/utils/ben
chmark/src/benchmark_register.h:17:46: error: expected primary-expression before '>' token
|    17 |   static const T kmax = std::numeric_limits<T>::max();
|       |                                              ^
| /mnt/b/yoe/master/build/tmp/work/riscv64-yoe-linux/rust-llvm/1.49.0-r0/rustc-1.49.0-src/src/llvm-project/llvm/utils/ben
chmark/src/benchmark_register.h:17:49: error: '::max' has not been declared; did you mean 'std::max'?
|    17 |   static const T kmax = std::numeric_limits<T>::max();
|       |                                                 ^~~
|       |                                                 std::max
```
