### PR TITLE
cargo.bbclass: support cargo's progress indicator

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -46,6 +46,7 @@ oe_cargo_build () {
 	"${CARGO}" build ${CARGO_BUILD_FLAGS} "$@"
 }
 
+do_compile[progress] = "outof:\s+(\d+)/(\d+)"
 cargo_do_compile () {
 	oe_cargo_fix_env
 	oe_cargo_build

--- a/classes/cargo_common.bbclass
+++ b/classes/cargo_common.bbclass
@@ -97,6 +97,13 @@ cargo_common_do_configure () {
 		target-dir = "${B}/target"
 		EOF
 	fi
+
+	cat <<- EOF >> ${CARGO_HOME}/config
+
+	[term]
+	progress.when = 'always'
+	progress.width = 80
+	EOF
 }
 
 oe_cargo_fix_env () {


### PR DESCRIPTION
Recent versions of cargo support always showing the progress indicator.
By default the progress indicator is hidden if the output is not a tty.
For bitbake builds, the output is redirected to a file and not a tty.
However, if we tell cargo to always show the progress indicator, bitbake
can parse it and will show the user how the rust build is progressing.