### PR TITLE
rust.inc: add strict-align when target is ARMv4

### DIFF
--- a/recipes-devtools/rust/rust-common.inc
+++ b/recipes-devtools/rust/rust-common.inc
@@ -39,6 +39,9 @@ def llvm_features_from_tune(d):
     if ('armv6' in mach_overrides) or ('armv6' in feat):
         f.append("+v6")
 
+    if ('armv4' in mach_overrides) or ('armv4' in feat):
+        f.append("+strict-align")
+
     if 'dsp' in feat:
         f.append("+dsp")
 


### PR DESCRIPTION
Not sure if this is the correct way to do this, but this fixes #337 