### PR TITLE
nativesdk: Package rust sources

### DIFF
--- a/recipes-core/packagegroups/packagegroup-rust-cross-canadian.bb
+++ b/recipes-core/packagegroups/packagegroup-rust-cross-canadian.bb
@@ -11,5 +11,6 @@ CARGO="cargo-cross-canadian-${TRANSLATED_TARGET_ARCH}"
 RDEPENDS_${PN} = " \
     ${@all_multilib_tune_values(d, 'RUST')} \
     ${@all_multilib_tune_values(d, 'CARGO')} \
+    rust-cross-canadian-src \
 "
 

--- a/recipes-devtools/rust/rust-cross-canadian.inc
+++ b/recipes-devtools/rust/rust-cross-canadian.inc
@@ -14,7 +14,8 @@ DEPENDS += "  \
            "
 RUSTLIB_TARGET_PN = "rust-cross-canadian-rustlib-target-${TRANSLATED_TARGET_ARCH}"
 RUSTLIB_HOST_PN = "rust-cross-canadian-rustlib-host-${TRANSLATED_TARGET_ARCH}"
-RUSTLIB_PKGS = "${RUSTLIB_TARGET_PN} ${RUSTLIB_HOST_PN}"
+RUSTLIB_SRC_PN = "rust-cross-canadian-src"
+RUSTLIB_PKGS = "${RUSTLIB_SRC_PN} ${RUSTLIB_TARGET_PN} ${RUSTLIB_HOST_PN}"
 PN = "rust-cross-canadian-${TRANSLATED_TARGET_ARCH}"
 
 PACKAGES = "${RUSTLIB_PKGS} ${PN}"
@@ -190,7 +191,13 @@ do_install () {
 
     install -m 0644 "${WORKDIR}/targets/${TARGET_SYS}.json" "${RUSTLIB_DIR}"
 
-    # TODO package the sources.
+    SRC_DIR=${RUSTLIB_DIR}/src/rust
+    install -d ${SRC_DIR}/src/llvm-project
+    cp -pRd build/${SNAPSHOT_BUILD_SYS}/stage2/lib/rustlib/src/rust/src/llvm-project/libunwind ${SRC_DIR}/src/llvm-project
+    cp -pRd build/${SNAPSHOT_BUILD_SYS}/stage2/lib/rustlib/src/rust/library ${SRC_DIR}
+    cp -pRd build/${SNAPSHOT_BUILD_SYS}/stage2/lib/rustlib/src/rust/Cargo.lock ${SRC_DIR}
+    # Remove executable bit from any files so then Yocto doesn't try to relocate.
+    chmod -R -x+X ${SRC_DIR}
 
     ENV_SETUP_DIR=${D}${base_prefix}/environment-setup.d
     mkdir "${ENV_SETUP_DIR}"
@@ -217,8 +224,10 @@ PKG_RUSTLIB_DIR = "${PKG_SYS_LIBDIR}/${TARGET_SYS}/rustlib"
 FILES_${PN} = "${PKG_SYS_LIBDIR}/*.so ${PKG_SYS_BINDIR} ${base_prefix}/environment-setup.d"
 FILES_${RUSTLIB_TARGET_PN} = "${PKG_RUSTLIB_DIR}/${TARGET_SYS} ${PKG_RUSTLIB_DIR}/${TARGET_SYS}.json"
 FILES_${RUSTLIB_HOST_PN} = "${PKG_RUSTLIB_DIR}/${BUILD_ARCH}-unknown-linux-gnu"
+FILES_${RUSTLIB_SRC_PN} = "${PKG_RUSTLIB_DIR}/src"
 
 SUMMARY_${RUSTLIB_TARGET_PN} = "Rust cross canadian libaries for ${TARGET_SYS}"
 SUMMARY_${RUSTLIB_HOST_PN} = "Rust cross canadian libaries for ${HOST_SYS}"
+SUMMARY_${RUSTLIB_SRC_PN} = "Rust standard library sources for cross canadian toolchain"
 SUMMARY_${PN} = "Rust crost canadian compiler"
 

--- a/recipes-devtools/rust/rust-cross-canadian.inc
+++ b/recipes-devtools/rust/rust-cross-canadian.inc
@@ -193,10 +193,10 @@ do_install () {
 
     SRC_DIR=${RUSTLIB_DIR}/src/rust
     install -d ${SRC_DIR}/src/llvm-project
-    cp -pRd build/${SNAPSHOT_BUILD_SYS}/stage2/lib/rustlib/src/rust/src/llvm-project/libunwind ${SRC_DIR}/src/llvm-project
-    cp -pRd build/${SNAPSHOT_BUILD_SYS}/stage2/lib/rustlib/src/rust/library ${SRC_DIR}
-    cp -pRd build/${SNAPSHOT_BUILD_SYS}/stage2/lib/rustlib/src/rust/Cargo.lock ${SRC_DIR}
-    # Remove executable bit from any files so then Yocto doesn't try to relocate.
+    cp -R --no-dereference build/${SNAPSHOT_BUILD_SYS}/stage2/lib/rustlib/src/rust/src/llvm-project/libunwind ${SRC_DIR}/src/llvm-project
+    cp -R --no-dereference build/${SNAPSHOT_BUILD_SYS}/stage2/lib/rustlib/src/rust/library ${SRC_DIR}
+    cp --no-dereference build/${SNAPSHOT_BUILD_SYS}/stage2/lib/rustlib/src/rust/Cargo.lock ${SRC_DIR}
+    # Remove executable bit from any files so then SDK doesn't try to relocate.
     chmod -R -x+X ${SRC_DIR}
 
     ENV_SETUP_DIR=${D}${base_prefix}/environment-setup.d


### PR DESCRIPTION
This mimics what rustup packages into the toolchain contents. The
presence of the sources for the exact std lib can be useful for the
development and IDE integration.

Signed-off-by: Anatol Belski <anbelski@linux.microsoft.com>