### PR TITLE
nativesdk: Add some tools in a separate recipe

### DIFF
--- a/classes/rust-common.bbclass
+++ b/classes/rust-common.bbclass
@@ -138,6 +138,12 @@ create_wrapper () {
 	chmod +x "${file}"
 }
 
+export WRAPPER_TARGET_CC = "${CC}"
+export WRAPPER_TARGET_CXX = "${CXX}"
+export WRAPPER_TARGET_CCLD = "${CCLD}"
+export WRAPPER_TARGET_LDFLAGS = "${LDFLAGS}"
+export WRAPPER_TARGET_AR = "${AR}"
+
 # compiler is used by gcc-rs
 # linker is used by rustc/cargo
 # archiver is used by the build of libstd-rs
@@ -154,13 +160,14 @@ do_rust_create_wrappers () {
 	create_wrapper "${RUST_BUILD_AR}" "${BUILD_AR}"
 
 	# Yocto Target / Rust Target C compiler
-	create_wrapper "${RUST_TARGET_CC}" "${CC}"
+	create_wrapper "${RUST_TARGET_CC}" "${WRAPPER_TARGET_CC}"
 	# Yocto Target / Rust Target C++ compiler
-	create_wrapper "${RUST_TARGET_CXX}" "${CXX}"
+	create_wrapper "${RUST_TARGET_CXX}" "${WRAPPER_TARGET_CXX}"
 	# Yocto Target / Rust Target linker
-	create_wrapper "${RUST_TARGET_CCLD}" "${CCLD}" "${LDFLAGS}"
+	create_wrapper "${RUST_TARGET_CCLD}" "${WRAPPER_TARGET_CCLD}" "${WRAPPER_TARGET_LDFLAGS}"
 	# Yocto Target / Rust Target archiver
-	create_wrapper "${RUST_TARGET_AR}" "${AR}"
+	create_wrapper "${RUST_TARGET_AR}" "${WRAPPER_TARGET_AR}"
+
 }
 
 addtask rust_create_wrappers before do_configure after do_patch

--- a/recipes-core/packagegroups/packagegroup-rust-cross-canadian.bb
+++ b/recipes-core/packagegroups/packagegroup-rust-cross-canadian.bb
@@ -7,10 +7,12 @@ PACKAGEGROUP_DISABLE_COMPLEMENTARY = "1"
 
 RUST="rust-cross-canadian-${TRANSLATED_TARGET_ARCH}"
 CARGO="cargo-cross-canadian-${TRANSLATED_TARGET_ARCH}"
+RUST_TOOLS="rust-tools-cross-canadian-${TRANSLATED_TARGET_ARCH}"
 
 RDEPENDS_${PN} = " \
     ${@all_multilib_tune_values(d, 'RUST')} \
     ${@all_multilib_tune_values(d, 'CARGO')} \
     rust-cross-canadian-src \
+    ${@all_multilib_tune_values(d, 'RUST_TOOLS')} \
 "
 

--- a/recipes-devtools/rust/rust-cross-canadian-common.inc
+++ b/recipes-devtools/rust/rust-cross-canadian-common.inc
@@ -1,0 +1,159 @@
+
+RUST_ALTERNATE_EXE_PATH = "${STAGING_LIBDIR_NATIVE}/llvm-rust/bin/llvm-config"
+
+require rust-target.inc
+
+inherit cross-canadian
+
+DEPENDS += "  \
+            virtual/${HOST_PREFIX}gcc-crosssdk \
+            virtual/nativesdk-libc rust-llvm-native \
+            virtual/${TARGET_PREFIX}compilerlibs \
+            virtual/nativesdk-${HOST_PREFIX}compilerlibs \
+            gcc-cross-${TARGET_ARCH} \
+           "
+
+# The host tools are likely not to be able to do the necessary operation on
+# the target architecturea. Alternatively one could check compatibility
+# between host/target.
+EXCLUDE_FROM_SHLIBS_${RUSTLIB_TARGET_PN} = "1"
+
+DEBUG_PREFIX_MAP = "-fdebug-prefix-map=${WORKDIR}=/usr/src/debug/${PN}/${EXTENDPE}${PV}-${PR} \
+                    -fdebug-prefix-map=${STAGING_DIR_HOST}= \
+                    -fdebug-prefix-map=${STAGING_DIR_NATIVE}= \
+                    "
+
+LLVM_TARGET[x86_64] = "${RUST_HOST_SYS}"
+python do_rust_gen_targets () {
+    wd = d.getVar('WORKDIR') + '/targets/'
+    rust_gen_target(d, 'TARGET', wd, d.getVar('TARGET_LLVM_FEATURES') or "", d.getVar('TARGET_LLVM_CPU'), d.getVar('TARGET_ARCH'))
+    rust_gen_target(d, 'HOST', wd, "", "generic", d.getVar('HOST_ARCH'))
+    rust_gen_target(d, 'BUILD', wd, "", "generic", d.getVar('BUILD_ARCH'))
+}
+
+INHIBIT_DEFAULT_RUST_DEPS = "1"
+
+export TARGET_CC = "${CCACHE}${TARGET_PREFIX}gcc --sysroot=${STAGING_DIR_TARGET} ${TARGET_CC_ARCH} ${SECURITY_NOPIE_CFLAGS}"
+export TARGET_CXX = "${CCACHE}${TARGET_PREFIX}g++ --sysroot=${STAGING_DIR_TARGET} ${TARGET_CC_ARCH} ${SECURITY_NOPIE_CFLAGS}"
+export TARGET_CCLD = "${TARGET_PREFIX}gcc --sysroot=${STAGING_DIR_TARGET} ${TARGET_CC_ARCH} ${SECURITY_NOPIE_CFLAGS}"
+export TARGET_AR = "${TARGET_PREFIX}ar"
+
+do_rust_create_wrappers () {
+	mkdir -p "${WRAPPER_DIR}"
+
+	# Yocto Build / Rust Host C compiler
+	create_wrapper "${RUST_BUILD_CC}" "${BUILD_CC}"
+	# Yocto Build / Rust Host C++ compiler
+	create_wrapper "${RUST_BUILD_CXX}" "${BUILD_CXX}"
+	# Yocto Build / Rust Host linker
+	create_wrapper "${RUST_BUILD_CCLD}" "${BUILD_CCLD}" "${BUILD_LDFLAGS}"
+	# Yocto Build / Rust Host archiver
+	create_wrapper "${RUST_BUILD_AR}" "${BUILD_AR}"
+
+	# Yocto Target / Rust Target C compiler
+	create_wrapper "${RUST_TARGET_CC}" "${TARGET_CC}"
+	# Yocto Target / Rust Target C++ compiler
+	create_wrapper "${RUST_TARGET_CXX}" "${TARGET_CXX}"
+	# Yocto Target / Rust Target linker
+	create_wrapper "${RUST_TARGET_CCLD}" "${TARGET_CCLD}" "${TARGET_LDFLAGS}"
+	# Yocto Target / Rust Target archiver
+	create_wrapper "${RUST_TARGET_AR}" "${TARGET_AR}"
+}
+
+python do_configure() {
+    import json
+    from distutils.version import LooseVersion
+    try:
+        import configparser
+    except ImportError:
+        import ConfigParser as configparser
+
+    # toml is rather similar to standard ini like format except it likes values
+    # that look more JSON like. So for our purposes simply escaping all values
+    # as JSON seem to work fine.
+
+    e = lambda s: json.dumps(s)
+
+    config = configparser.RawConfigParser()
+
+    # [target.ARCH-poky-linux]
+    target_section = "target.{}".format(d.getVar('TARGET_SYS', True))
+    config.add_section(target_section)
+
+    llvm_config = d.expand("${YOCTO_ALTERNATE_EXE_PATH}")
+    config.set(target_section, "llvm-config", e(llvm_config))
+
+    config.set(target_section, "cxx", e(d.expand("${RUST_TARGET_CXX}")))
+    config.set(target_section, "cc", e(d.expand("${RUST_TARGET_CC}")))
+    config.set(target_section, "ar", e(d.expand("${RUST_TARGET_AR}")))
+
+    # If we don't do this rust-native will compile it's own llvm for BUILD.
+    # [target.${BUILD_ARCH}-unknown-linux-gnu]
+    target_section = "target.{}".format(d.getVar('SNAPSHOT_BUILD_SYS', True))
+    config.add_section(target_section)
+
+    config.set(target_section, "llvm-config", e(llvm_config))
+
+    config.set(target_section, "cxx", e(d.expand("${RUST_BUILD_CXX}")))
+    config.set(target_section, "cc", e(d.expand("${RUST_BUILD_CC}")))
+    config.set(target_section, "ar", e(d.expand("${RUST_BUILD_AR}")))
+
+    # [rust]
+    config.add_section("rust")
+    config.set("rust", "rpath", e(True))
+    config.set("rust", "channel", e("stable"))
+
+    if LooseVersion(d.getVar("PV")) < LooseVersion("1.32.0"):
+        config.set("rust", "use-jemalloc", e(False))
+
+    # Whether or not to optimize the compiler and standard library
+    config.set("rust", "optimize", e(True))
+
+    # [build]
+    config.add_section("build")
+    config.set("build", "submodules", e(False))
+    config.set("build", "docs", e(False))
+
+    rustc = d.expand("${WORKDIR}/rust-snapshot/bin/rustc")
+    config.set("build", "rustc", e(rustc))
+
+    cargo = d.expand("${WORKDIR}/rust-snapshot/bin/cargo")
+    config.set("build", "cargo", e(cargo))
+
+    config.set("build", "vendor", e(True))
+
+    targets = [d.getVar("TARGET_SYS", True), "{}-unknown-linux-gnu".format(d.getVar("HOST_ARCH", True))]
+    config.set("build", "target", e(targets))
+
+    hosts = ["{}-unknown-linux-gnu".format(d.getVar("HOST_ARCH", True))]
+    config.set("build", "host", e(hosts))
+
+    # We can't use BUILD_SYS since that is something the rust snapshot knows
+    # nothing about when trying to build some stage0 tools (like fabricate)
+    config.set("build", "build", e(d.getVar("SNAPSHOT_BUILD_SYS", True)))
+
+    # [install]
+    config.add_section("install")
+    # ./x.py install doesn't have any notion of "destdir"
+    # but we can prepend ${D} to all the directories instead
+    config.set("install", "prefix",  e(d.getVar("D", True) + d.getVar("prefix", True)))
+    config.set("install", "bindir",  e(d.getVar("D", True) + d.getVar("bindir", True)))
+    config.set("install", "libdir",  e(d.getVar("D", True) + d.getVar("libdir", True)))
+    config.set("install", "datadir", e(d.getVar("D", True) + d.getVar("datadir", True)))
+    config.set("install", "mandir",  e(d.getVar("D", True) + d.getVar("mandir", True)))
+
+    with open("config.toml", "w") as f:
+        f.write('changelog-seen = 2\n\n')
+        config.write(f)
+
+    # set up ${WORKDIR}/cargo_home
+    bb.build.exec_func("setup_cargo_environment", d)
+}
+
+INSANE_SKIP_${RUSTLIB_TARGET_PN} = "file-rdeps arch ldflags"
+SKIP_FILEDEPS_${RUSTLIB_TARGET_PN} = "1"
+
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_SYSROOT_STRIP = "1"
+

--- a/recipes-devtools/rust/rust-cross-canadian-common.inc
+++ b/recipes-devtools/rust/rust-cross-canadian-common.inc
@@ -39,94 +39,9 @@ export WRAPPER_TARGET_CCLD = "${TARGET_PREFIX}gcc --sysroot=${STAGING_DIR_TARGET
 export WRAPPER_TARGET_LDFLAGS = "${TARGET_LDFLAGS}"
 export WRAPPER_TARGET_AR = "${TARGET_PREFIX}ar"
 
-python do_configure() {
-    import json
-    from distutils.version import LooseVersion
-    try:
-        import configparser
-    except ImportError:
-        import ConfigParser as configparser
-
-    # toml is rather similar to standard ini like format except it likes values
-    # that look more JSON like. So for our purposes simply escaping all values
-    # as JSON seem to work fine.
-
-    e = lambda s: json.dumps(s)
-
-    config = configparser.RawConfigParser()
-
-    # [target.ARCH-poky-linux]
-    target_section = "target.{}".format(d.getVar('TARGET_SYS', True))
-    config.add_section(target_section)
-
-    llvm_config = d.expand("${YOCTO_ALTERNATE_EXE_PATH}")
-    config.set(target_section, "llvm-config", e(llvm_config))
-
-    config.set(target_section, "cxx", e(d.expand("${RUST_TARGET_CXX}")))
-    config.set(target_section, "cc", e(d.expand("${RUST_TARGET_CC}")))
-    config.set(target_section, "ar", e(d.expand("${RUST_TARGET_AR}")))
-
-    # If we don't do this rust-native will compile it's own llvm for BUILD.
-    # [target.${BUILD_ARCH}-unknown-linux-gnu]
-    target_section = "target.{}".format(d.getVar('SNAPSHOT_BUILD_SYS', True))
-    config.add_section(target_section)
-
-    config.set(target_section, "llvm-config", e(llvm_config))
-
-    config.set(target_section, "cxx", e(d.expand("${RUST_BUILD_CXX}")))
-    config.set(target_section, "cc", e(d.expand("${RUST_BUILD_CC}")))
-    config.set(target_section, "ar", e(d.expand("${RUST_BUILD_AR}")))
-
-    # [rust]
-    config.add_section("rust")
-    config.set("rust", "rpath", e(True))
-    config.set("rust", "channel", e("stable"))
-
-    if LooseVersion(d.getVar("PV")) < LooseVersion("1.32.0"):
-        config.set("rust", "use-jemalloc", e(False))
-
-    # Whether or not to optimize the compiler and standard library
-    config.set("rust", "optimize", e(True))
-
-    # [build]
-    config.add_section("build")
-    config.set("build", "submodules", e(False))
-    config.set("build", "docs", e(False))
-
-    rustc = d.expand("${WORKDIR}/rust-snapshot/bin/rustc")
-    config.set("build", "rustc", e(rustc))
-
-    cargo = d.expand("${WORKDIR}/rust-snapshot/bin/cargo")
-    config.set("build", "cargo", e(cargo))
-
-    config.set("build", "vendor", e(True))
-
+python do_configure_prepend() {
     targets = [d.getVar("TARGET_SYS", True), "{}-unknown-linux-gnu".format(d.getVar("HOST_ARCH", True))]
-    config.set("build", "target", e(targets))
-
     hosts = ["{}-unknown-linux-gnu".format(d.getVar("HOST_ARCH", True))]
-    config.set("build", "host", e(hosts))
-
-    # We can't use BUILD_SYS since that is something the rust snapshot knows
-    # nothing about when trying to build some stage0 tools (like fabricate)
-    config.set("build", "build", e(d.getVar("SNAPSHOT_BUILD_SYS", True)))
-
-    # [install]
-    config.add_section("install")
-    # ./x.py install doesn't have any notion of "destdir"
-    # but we can prepend ${D} to all the directories instead
-    config.set("install", "prefix",  e(d.getVar("D", True) + d.getVar("prefix", True)))
-    config.set("install", "bindir",  e(d.getVar("D", True) + d.getVar("bindir", True)))
-    config.set("install", "libdir",  e(d.getVar("D", True) + d.getVar("libdir", True)))
-    config.set("install", "datadir", e(d.getVar("D", True) + d.getVar("datadir", True)))
-    config.set("install", "mandir",  e(d.getVar("D", True) + d.getVar("mandir", True)))
-
-    with open("config.toml", "w") as f:
-        f.write('changelog-seen = 2\n\n')
-        config.write(f)
-
-    # set up ${WORKDIR}/cargo_home
-    bb.build.exec_func("setup_cargo_environment", d)
 }
 
 INSANE_SKIP_${RUSTLIB_TARGET_PN} = "file-rdeps arch ldflags"

--- a/recipes-devtools/rust/rust-cross-canadian-common.inc
+++ b/recipes-devtools/rust/rust-cross-canadian-common.inc
@@ -33,32 +33,11 @@ python do_rust_gen_targets () {
 
 INHIBIT_DEFAULT_RUST_DEPS = "1"
 
-export TARGET_CC = "${CCACHE}${TARGET_PREFIX}gcc --sysroot=${STAGING_DIR_TARGET} ${TARGET_CC_ARCH} ${SECURITY_NOPIE_CFLAGS}"
-export TARGET_CXX = "${CCACHE}${TARGET_PREFIX}g++ --sysroot=${STAGING_DIR_TARGET} ${TARGET_CC_ARCH} ${SECURITY_NOPIE_CFLAGS}"
-export TARGET_CCLD = "${TARGET_PREFIX}gcc --sysroot=${STAGING_DIR_TARGET} ${TARGET_CC_ARCH} ${SECURITY_NOPIE_CFLAGS}"
-export TARGET_AR = "${TARGET_PREFIX}ar"
-
-do_rust_create_wrappers () {
-	mkdir -p "${WRAPPER_DIR}"
-
-	# Yocto Build / Rust Host C compiler
-	create_wrapper "${RUST_BUILD_CC}" "${BUILD_CC}"
-	# Yocto Build / Rust Host C++ compiler
-	create_wrapper "${RUST_BUILD_CXX}" "${BUILD_CXX}"
-	# Yocto Build / Rust Host linker
-	create_wrapper "${RUST_BUILD_CCLD}" "${BUILD_CCLD}" "${BUILD_LDFLAGS}"
-	# Yocto Build / Rust Host archiver
-	create_wrapper "${RUST_BUILD_AR}" "${BUILD_AR}"
-
-	# Yocto Target / Rust Target C compiler
-	create_wrapper "${RUST_TARGET_CC}" "${TARGET_CC}"
-	# Yocto Target / Rust Target C++ compiler
-	create_wrapper "${RUST_TARGET_CXX}" "${TARGET_CXX}"
-	# Yocto Target / Rust Target linker
-	create_wrapper "${RUST_TARGET_CCLD}" "${TARGET_CCLD}" "${TARGET_LDFLAGS}"
-	# Yocto Target / Rust Target archiver
-	create_wrapper "${RUST_TARGET_AR}" "${TARGET_AR}"
-}
+export WRAPPER_TARGET_CC = "${CCACHE}${TARGET_PREFIX}gcc --sysroot=${STAGING_DIR_TARGET} ${TARGET_CC_ARCH} ${SECURITY_NOPIE_CFLAGS}"
+export WRAPPER_TARGET_CXX = "${CCACHE}${TARGET_PREFIX}g++ --sysroot=${STAGING_DIR_TARGET} ${TARGET_CC_ARCH} ${SECURITY_NOPIE_CFLAGS}"
+export WRAPPER_TARGET_CCLD = "${TARGET_PREFIX}gcc --sysroot=${STAGING_DIR_TARGET} ${TARGET_CC_ARCH} ${SECURITY_NOPIE_CFLAGS}"
+export WRAPPER_TARGET_LDFLAGS = "${TARGET_LDFLAGS}"
+export WRAPPER_TARGET_AR = "${TARGET_PREFIX}ar"
 
 python do_configure() {
     import json

--- a/recipes-devtools/rust/rust-cross-canadian.inc
+++ b/recipes-devtools/rust/rust-cross-canadian.inc
@@ -1,17 +1,6 @@
 
-RUST_ALTERNATE_EXE_PATH = "${STAGING_LIBDIR_NATIVE}/llvm-rust/bin/llvm-config"
+require rust-cross-canadian-common.inc
 
-require rust-target.inc
-
-inherit cross-canadian
-
-DEPENDS += "  \
-            virtual/${HOST_PREFIX}gcc-crosssdk \
-            virtual/nativesdk-libc rust-llvm-native \
-            virtual/${TARGET_PREFIX}compilerlibs \
-            virtual/nativesdk-${HOST_PREFIX}compilerlibs \
-            gcc-cross-${TARGET_ARCH} \
-           "
 RUSTLIB_TARGET_PN = "rust-cross-canadian-rustlib-target-${TRANSLATED_TARGET_ARCH}"
 RUSTLIB_HOST_PN = "rust-cross-canadian-rustlib-host-${TRANSLATED_TARGET_ARCH}"
 RUSTLIB_SRC_PN = "rust-cross-canadian-src"
@@ -21,147 +10,10 @@ PN = "rust-cross-canadian-${TRANSLATED_TARGET_ARCH}"
 PACKAGES = "${RUSTLIB_PKGS} ${PN}"
 RDEPENDS_${PN} += "${RUSTLIB_PKGS}"
 
-# The host tools are likely not to be able to do the necessary operation on
-# the target architecturea. Alternatively one could check compatibility
-# between host/target.
-EXCLUDE_FROM_SHLIBS_${RUSTLIB_TARGET_PN} = "1"
-
-DEBUG_PREFIX_MAP = "-fdebug-prefix-map=${WORKDIR}=/usr/src/debug/${PN}/${EXTENDPE}${PV}-${PR} \
-                    -fdebug-prefix-map=${STAGING_DIR_HOST}= \
-                    -fdebug-prefix-map=${STAGING_DIR_NATIVE}= \
-                    "
-
-LLVM_TARGET[x86_64] = "${RUST_HOST_SYS}"
-python do_rust_gen_targets () {
-    wd = d.getVar('WORKDIR') + '/targets/'
-    rust_gen_target(d, 'TARGET', wd, d.getVar('TARGET_LLVM_FEATURES') or "", d.getVar('TARGET_LLVM_CPU'), d.getVar('TARGET_ARCH'))
-    rust_gen_target(d, 'HOST', wd, "", "generic", d.getVar('HOST_ARCH'))
-    rust_gen_target(d, 'BUILD', wd, "", "generic", d.getVar('BUILD_ARCH'))
-}
-
-INHIBIT_DEFAULT_RUST_DEPS = "1"
-
 # The default behaviour of x.py changed in 1.47+ so now we need to
 # explicitly ask for the stage 2 compiler to be assembled.
 do_compile () {
     rust_runx build --stage 2
-}
-
-export TARGET_CC = "${CCACHE}${TARGET_PREFIX}gcc --sysroot=${STAGING_DIR_TARGET} ${TARGET_CC_ARCH} ${SECURITY_NOPIE_CFLAGS}"
-export TARGET_CXX = "${CCACHE}${TARGET_PREFIX}g++ --sysroot=${STAGING_DIR_TARGET} ${TARGET_CC_ARCH} ${SECURITY_NOPIE_CFLAGS}"
-export TARGET_CCLD = "${TARGET_PREFIX}gcc --sysroot=${STAGING_DIR_TARGET} ${TARGET_CC_ARCH} ${SECURITY_NOPIE_CFLAGS}"
-export TARGET_AR = "${TARGET_PREFIX}ar"
-
-do_rust_create_wrappers () {
-	mkdir -p "${WRAPPER_DIR}"
-
-	# Yocto Build / Rust Host C compiler
-	create_wrapper "${RUST_BUILD_CC}" "${BUILD_CC}"
-	# Yocto Build / Rust Host C++ compiler
-	create_wrapper "${RUST_BUILD_CXX}" "${BUILD_CXX}"
-	# Yocto Build / Rust Host linker
-	create_wrapper "${RUST_BUILD_CCLD}" "${BUILD_CCLD}" "${BUILD_LDFLAGS}"
-	# Yocto Build / Rust Host archiver
-	create_wrapper "${RUST_BUILD_AR}" "${BUILD_AR}"
-
-	# Yocto Target / Rust Target C compiler
-	create_wrapper "${RUST_TARGET_CC}" "${TARGET_CC}"
-	# Yocto Target / Rust Target C++ compiler
-	create_wrapper "${RUST_TARGET_CXX}" "${TARGET_CXX}"
-	# Yocto Target / Rust Target linker
-	create_wrapper "${RUST_TARGET_CCLD}" "${TARGET_CCLD}" "${TARGET_LDFLAGS}"
-	# Yocto Target / Rust Target archiver
-	create_wrapper "${RUST_TARGET_AR}" "${TARGET_AR}"
-}
-
-python do_configure() {
-    import json
-    from distutils.version import LooseVersion
-    try:
-        import configparser
-    except ImportError:
-        import ConfigParser as configparser
-
-    # toml is rather similar to standard ini like format except it likes values
-    # that look more JSON like. So for our purposes simply escaping all values
-    # as JSON seem to work fine.
-
-    e = lambda s: json.dumps(s)
-
-    config = configparser.RawConfigParser()
-
-    # [target.ARCH-poky-linux]
-    target_section = "target.{}".format(d.getVar('TARGET_SYS', True))
-    config.add_section(target_section)
-
-    llvm_config = d.expand("${YOCTO_ALTERNATE_EXE_PATH}")
-    config.set(target_section, "llvm-config", e(llvm_config))
-
-    config.set(target_section, "cxx", e(d.expand("${RUST_TARGET_CXX}")))
-    config.set(target_section, "cc", e(d.expand("${RUST_TARGET_CC}")))
-    config.set(target_section, "ar", e(d.expand("${RUST_TARGET_AR}")))
-
-    # If we don't do this rust-native will compile it's own llvm for BUILD.
-    # [target.${BUILD_ARCH}-unknown-linux-gnu]
-    target_section = "target.{}".format(d.getVar('SNAPSHOT_BUILD_SYS', True))
-    config.add_section(target_section)
-
-    config.set(target_section, "llvm-config", e(llvm_config))
-
-    config.set(target_section, "cxx", e(d.expand("${RUST_BUILD_CXX}")))
-    config.set(target_section, "cc", e(d.expand("${RUST_BUILD_CC}")))
-    config.set(target_section, "ar", e(d.expand("${RUST_BUILD_AR}")))
-
-    # [rust]
-    config.add_section("rust")
-    config.set("rust", "rpath", e(True))
-    config.set("rust", "channel", e("stable"))
-
-    if LooseVersion(d.getVar("PV")) < LooseVersion("1.32.0"):
-        config.set("rust", "use-jemalloc", e(False))
-
-    # Whether or not to optimize the compiler and standard library
-    config.set("rust", "optimize", e(True))
-
-    # [build]
-    config.add_section("build")
-    config.set("build", "submodules", e(False))
-    config.set("build", "docs", e(False))
-
-    rustc = d.expand("${WORKDIR}/rust-snapshot/bin/rustc")
-    config.set("build", "rustc", e(rustc))
-
-    cargo = d.expand("${WORKDIR}/rust-snapshot/bin/cargo")
-    config.set("build", "cargo", e(cargo))
-
-    config.set("build", "vendor", e(True))
-
-    targets = [d.getVar("TARGET_SYS", True), "{}-unknown-linux-gnu".format(d.getVar("HOST_ARCH", True))]
-    config.set("build", "target", e(targets))
-
-    hosts = ["{}-unknown-linux-gnu".format(d.getVar("HOST_ARCH", True))]
-    config.set("build", "host", e(hosts))
-
-    # We can't use BUILD_SYS since that is something the rust snapshot knows
-    # nothing about when trying to build some stage0 tools (like fabricate)
-    config.set("build", "build", e(d.getVar("SNAPSHOT_BUILD_SYS", True)))
-
-    # [install]
-    config.add_section("install")
-    # ./x.py install doesn't have any notion of "destdir"
-    # but we can prepend ${D} to all the directories instead
-    config.set("install", "prefix",  e(d.getVar("D", True) + d.getVar("prefix", True)))
-    config.set("install", "bindir",  e(d.getVar("D", True) + d.getVar("bindir", True)))
-    config.set("install", "libdir",  e(d.getVar("D", True) + d.getVar("libdir", True)))
-    config.set("install", "datadir", e(d.getVar("D", True) + d.getVar("datadir", True)))
-    config.set("install", "mandir",  e(d.getVar("D", True) + d.getVar("mandir", True)))
-
-    with open("config.toml", "w") as f:
-        f.write('changelog-seen = 2\n\n')
-        config.write(f)
-
-    # set up ${WORKDIR}/cargo_home
-    bb.build.exec_func("setup_cargo_environment", d)
 }
 
 do_install () {
@@ -210,13 +62,6 @@ do_install () {
 
     chown -R root.root ${D}
 }
-
-INSANE_SKIP_${RUSTLIB_TARGET_PN} = "file-rdeps arch ldflags"
-SKIP_FILEDEPS_${RUSTLIB_TARGET_PN} = "1"
-
-INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
-INHIBIT_PACKAGE_STRIP = "1"
-INHIBIT_SYSROOT_STRIP = "1"
 
 PKG_SYS_LIBDIR = "${SDKPATHNATIVE}/usr/lib"
 PKG_SYS_BINDIR = "${SDKPATHNATIVE}/usr/bin"

--- a/recipes-devtools/rust/rust-tools-cross-canadian.inc
+++ b/recipes-devtools/rust/rust-tools-cross-canadian.inc
@@ -1,0 +1,38 @@
+
+require rust-cross-canadian-common.inc
+
+RUST_TOOLS_CLIPPY_PN = "rust-tools-clippy-cross-canadian-${TRANSLATED_TARGET_ARCH}"
+RUST_TOOLS_RUSTFMT_PN = "rust-tools-rustfmt-cross-canadian-${TRANSLATED_TARGET_ARCH}"
+RUST_TOOLS_PKGS = "${RUST_TOOLS_CLIPPY_PN} ${RUST_TOOLS_RUSTFMT_PN}"
+PN = "rust-tools-cross-canadian-${TRANSLATED_TARGET_ARCH}"
+
+PACKAGES = "${RUST_TOOLS_CLIPPY_PN} ${RUST_TOOLS_RUSTFMT_PN} ${PN}"
+RDEPENDS_${PN} += "${RUST_TOOLS_PKGS}"
+
+do_compile () {
+    rust_runx build --stage 2 src/tools/clippy
+    rust_runx build --stage 2 src/tools/rustfmt
+}
+
+do_install () {
+    SYS_BINDIR=$(dirname ${D}${bindir})
+
+    install -d "${SYS_BINDIR}"
+    cp build/${SNAPSHOT_BUILD_SYS}/stage2-tools-bin/* ${SYS_BINDIR}
+    for i in ${SYS_BINDIR}/*; do
+	chrpath -r "\$ORIGIN/../lib" ${i}
+    done
+
+    chown -R root.root ${D}
+}
+
+ALLOW_EMPTY_${PN} = "1"
+
+PKG_SYS_BINDIR = "${SDKPATHNATIVE}/usr/bin"
+FILES_${RUST_TOOLS_CLIPPY_PN} = "${PKG_SYS_BINDIR}/cargo-clippy ${PKG_SYS_BINDIR}/clippy-driver"
+FILES_${RUST_TOOLS_RUSTFMT_PN} = "${PKG_SYS_BINDIR}/rustfmt"
+
+SUMMARY_${PN} = "Rust helper tools"
+SUMMARY_${RUST_TOOLS_CLIPPY_PN} = "A collection of lints to catch common mistakes and improve your Rust code"
+SUMMARY_${RUST_TOOLS_RUSTFMT_PN} = "A tool for formatting Rust code according to style guidelines"
+

--- a/recipes-devtools/rust/rust-tools-cross-canadian_1.51.0.bb
+++ b/recipes-devtools/rust/rust-tools-cross-canadian_1.51.0.bb
@@ -1,0 +1,6 @@
+require rust-tools-cross-canadian.inc
+require rust-source-${PV}.inc
+require rust-snapshot-${PV}.inc
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/rust:"
+

--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -117,11 +117,13 @@ python do_configure() {
 
     config.set("build", "vendor", e(True))
 
-    targets = [d.getVar("TARGET_SYS", True)]
+    if not "targets" in locals():
+        targets = [d.getVar("TARGET_SYS", True)]
     config.set("build", "target", e(targets))
 
-    hosts = [d.getVar("HOST_SYS", True)]
-    config.set("build", "host", e(targets))
+    if not "hosts" in locals():
+        hosts = [d.getVar("HOST_SYS", True)]
+    config.set("build", "host", e(hosts))
 
     # We can't use BUILD_SYS since that is something the rust snapshot knows
     # nothing about when trying to build some stage0 tools (like fabricate)


### PR DESCRIPTION
This brings ATM:
- clippy
- rustfmt

Another approach might be to include these into the existing rust recipe,
but as we can't really use PACKAGECONFIG here it might just overload it.
This way, the tools will be built in parallel and still can be excluded
from the packgae group, if desired.

Signed-off-by: Anatol Belski <anbelski@linux.microsoft.com>