### PR TITLE
Added hashes for aarch64 binary snapshot packages

### DIFF
--- a/recipes-devtools/rust/rust-snapshot-1.49.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.49.0.inc
@@ -11,3 +11,8 @@ CARGO_VERSION = "1.48.0"
 SRC_URI[rust-std-snapshot-x86_64.sha256sum] = "1c00a6a0dabbf6290728b09f9307d9fa6cc985487f727075c68acd4a600ef3f8"
 SRC_URI[rustc-snapshot-x86_64.sha256sum] = "fc4d292a52cbb6b84fb9f065d0d7596064a9b957381d639d5a750d6e2bf02483"
 SRC_URI[cargo-snapshot-x86_64.sha256sum] = "b11d595581e2580c069b5039214e1031a0e4f87ff6490ac39f92f77857e37055"
+
+SRC_URI[rust-std-snapshot-aarch64.sha256sum] = "3a50eeb64a63a09f79bee49e01f72410d455b9ae1c7f07ebdb6dc0d40e9aa0bc"
+SRC_URI[rustc-snapshot-aarch64.sha256sum] = "ad2ca472b4abf228afd28e16840524a4f08a5efaeaae1d046ff1855c00f3994d"
+SRC_URI[cargo-snapshot-aarch64.sha256sum] = "9ea440709cf51cf28110847fd769e7fc937a01d03500edec5232408c4459fc80"
+

--- a/recipes-devtools/rust/rust-snapshot-1.51.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.51.0.inc
@@ -11,3 +11,8 @@ CARGO_VERSION = "1.50.0"
 SRC_URI[rust-std-snapshot-x86_64.sha256sum] = "f1eb68db2b28a56ed8701edba7cf3688011d903ca12ff9d85bd21d3f8f614792"
 SRC_URI[rustc-snapshot-x86_64.sha256sum] = "9bebd360bcd9b5bb58f2a02930b9db4ae291adef259c96377f1f4cbd240bcf86"
 SRC_URI[cargo-snapshot-x86_64.sha256sum] = "3cb2c68e987e5681fca9c930973f408a71151b1b255e69669a08e54d446ee803"
+
+SRC_URI[rust-std-snapshot-aarch64.sha256sum] = "1a1b1a540d531c89e866083f84ef67125dee108844e4e415b07c3a1000006544"
+SRC_URI[rustc-snapshot-aarch64.sha256sum] = "9b956d97d7e428ecd8634d467659ebdb5bd79c387b88363be8749eddd7f98756"
+SRC_URI[cargo-snapshot-aarch64.sha256sum] = "f3c772f455406f67991ac20cff56a4fcd2d01454e29280c566119ab5180307ea"
+


### PR DESCRIPTION
This adds the missing hash values to enable building on a aarch64 based host machine