### PR TITLE
Add support for Cargo features and flags

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -29,9 +29,29 @@ CARGO_SRC_DIR ??= ""
 # The actual path to the Cargo.toml
 MANIFEST_PATH ??= "${S}/${CARGO_SRC_DIR}/Cargo.toml"
 
+# Features and additional flags for 'cargo build'.
+#
+# CARGO_FEATURES supports both, a comma or space separated list. Disabling
+# default features or enabling all features could be done either by setting
+# CARGO_NO_DEFAULT_FEATURES or CARGO_ALL_FEATURES to "1" or passing
+# '--no-default-features' or '--all-features' via EXTRA_CARGO_FLAGS.
+CARGO_FEATURES ??= ""
+CARGO_NO_DEFAULT_FEATURES ??= ""
+CARGO_ALL_FEATURES ??= ""
+EXTRA_CARGO_FLAGS ??= ""
+
 RUSTFLAGS ??= ""
 BUILD_MODE = "${@['--release', ''][d.getVar('DEBUG_BUILD') == '1']}"
-CARGO_BUILD_FLAGS = "-v --target ${HOST_SYS} ${BUILD_MODE} --manifest-path=${MANIFEST_PATH}"
+CARGO_BUILD_FLAGS = "\
+    -v \
+    --target ${HOST_SYS} \
+    ${BUILD_MODE} \
+    --manifest-path=${MANIFEST_PATH} \
+    ${@oe.utils.conditional('CARGO_NO_DEFAULT_FEATURES', '1', '--no-default-features', '', d)} \
+    ${@oe.utils.conditional('CARGO_ALL_FEATURES', '1', '--all-features', '', d)} \
+    ${@oe.utils.conditional('CARGO_FEATURES', '', '', '--features "${CARGO_FEATURES}"', d)} \
+    ${EXTRA_CARGO_FLAGS} \
+"
 
 # This is based on the content of CARGO_BUILD_FLAGS and generally will need to
 # change if CARGO_BUILD_FLAGS changes.


### PR DESCRIPTION
- I was missing this feature for development builds to enable debug features of an application
- Adds support for enabling disabling Cargo features when building the application through new variables
- Adds support for passing generic flags/arguments to Cargo via `CARGO_EXTRA_FLAGS`
- The newly introduced variables aim to achieve some compatibility with [meta-rust-bin](https://github.com/rust-embedded/meta-rust-bin)
    - Using `CARGO_FEATURES` for feature selection
    - Providing `CARGO_EXTRA_FLAGS` for an alternative way setting `--all-features` and `--no-default-features`