### PR TITLE
rust_versions.inc: bump to latest rust versions

### DIFF
--- a/conf/distro/include/rust_versions.inc
+++ b/conf/distro/include/rust_versions.inc
@@ -1,7 +1,7 @@
 # include this in your distribution to easily switch between versions
 # just by changing RUST_VERSION variable
 
-RUST_VERSION ?= "1.51.0"
+RUST_VERSION ?= "1.66.0"
 
 PREFERRED_VERSION_cargo ?= "${RUST_VERSION}"
 PREFERRED_VERSION_cargo-native ?= "${RUST_VERSION}"


### PR DESCRIPTION
This was set to a rust version no longer carried in meta-rust. Bumping it to 1.66.0.