### PR TITLE
export RUST_TARGET_PATH

### DIFF
--- a/classes/rust-common.bbclass
+++ b/classes/rust-common.bbclass
@@ -8,7 +8,7 @@ RUSTLIB = "-L ${STAGING_LIBDIR}/rust"
 RUST_DEBUG_REMAP = "--remap-path-prefix=${WORKDIR}=/usr/src/debug/${PN}/${EXTENDPE}${PV}-${PR}"
 RUSTFLAGS += "${RUSTLIB} ${RUST_DEBUG_REMAP}"
 RUSTLIB_DEP ?= "libstd-rs"
-RUST_TARGET_PATH = "${STAGING_LIBDIR_NATIVE}/rustlib"
+export RUST_TARGET_PATH = "${STAGING_LIBDIR_NATIVE}/rustlib"
 RUST_PANIC_STRATEGY ?= "unwind"
 
 # Native builds are not effected by TCLIBC. Without this, rust-native


### PR DESCRIPTION
In the kirkstone branch and later rust is now available as a dependency for other packages. Among other thing the `python3-cryptography` use some rust binding. Thus it needs to run `rustc --print target-list`. If `RUST_TARGET_PATH` is not exported, then all the `rustc --print` invocation fail with: 

`Error loading target specification: Could not find specification for target "x86_64-linux". Run rustc --print target-list for a list of built-in targets`

This seems like those issue where the fix is to export the `RUST_TARGET_PATH`

https://github.com/rust-lang/cargo/issues/4865#issue-284617845
https://github.com/japaric/xargo/issues/44#issue-178701245

This is an other step toward to fix #380