### PR TITLE
Add Rust 1.73.0

### DIFF
--- a/conf/distro/include/rust_versions.inc
+++ b/conf/distro/include/rust_versions.inc
@@ -1,7 +1,7 @@
 # include this in your distribution to easily switch between versions
 # just by changing RUST_VERSION variable
 
-RUST_VERSION ?= "1.72.0"
+RUST_VERSION ?= "1.73.0"
 
 PREFERRED_VERSION_cargo ?= "${RUST_VERSION}"
 PREFERRED_VERSION_cargo-native ?= "${RUST_VERSION}"

--- a/recipes-devtools/cargo/cargo-cross-canadian_1.73.0.bb
+++ b/recipes-devtools/cargo/cargo-cross-canadian_1.73.0.bb
@@ -1,0 +1,6 @@
+require recipes-devtools/rust/rust-source-${PV}.inc
+require recipes-devtools/rust/rust-snapshot-${PV}.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/cargo-${PV}:"
+
+require cargo-cross-canadian.inc

--- a/recipes-devtools/cargo/cargo_1.73.0.bb
+++ b/recipes-devtools/cargo/cargo_1.73.0.bb
@@ -1,0 +1,4 @@
+require recipes-devtools/rust/rust-source-${PV}.inc
+require recipes-devtools/rust/rust-snapshot-${PV}.inc
+require cargo.inc
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/rust/libstd-rs_1.73.0.bb
+++ b/recipes-devtools/rust/libstd-rs_1.73.0.bb
@@ -1,0 +1,7 @@
+require rust-source-${PV}.inc
+require libstd-rs.inc
+
+LIC_FILES_CHKSUM = "file://../../COPYRIGHT;md5=c2cccf560306876da3913d79062a54b9"
+
+# libstd moved from src/libstd to library/std in 1.47+
+S = "${RUSTSRC}/library/std"

--- a/recipes-devtools/rust/rust-cross-canadian_1.73.0.bb
+++ b/recipes-devtools/rust/rust-cross-canadian_1.73.0.bb
@@ -1,0 +1,6 @@
+require rust-cross-canadian.inc
+require rust-source-${PV}.inc
+require rust-snapshot-${PV}.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/rust:"
+

--- a/recipes-devtools/rust/rust-cross_1.73.0.bb
+++ b/recipes-devtools/rust/rust-cross_1.73.0.bb
@@ -1,0 +1,6 @@
+require rust-cross.inc
+require rust-source-${PV}.inc
+
+# License file checksum needed for do_populate_lic when including a
+# Rust app in an image.
+LIC_FILES_CHKSUM="file://LICENSE-APACHE;md5=22a53954e4e0ec258dfce4391e905dac"

--- a/recipes-devtools/rust/rust-llvm_1.73.0.bb
+++ b/recipes-devtools/rust/rust-llvm_1.73.0.bb
@@ -1,0 +1,5 @@
+# check src/llvm-project/llvm/CMakeLists.txt for llvm version in use
+#
+LLVM_RELEASE = "17.0.2"
+require rust-source-${PV}.inc
+require rust-llvm.inc

--- a/recipes-devtools/rust/rust-snapshot-1.73.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.73.0.inc
@@ -1,0 +1,32 @@
+## This is information on the rust-snapshot (binary) used to build our current release.
+## snapshot info is taken from rust/src/stage0.json
+## Rust is self-hosting and bootstraps itself with a pre-built previous version of itself.
+## The exact (previous) version that has been used is specified in the source tarball.
+## The version is replicated here.
+## TODO: find a way to add additional SRC_URIs based on the contents of an
+##       earlier SRC_URI.
+
+SNAPSHOT_VERSION = "1.72.0"
+
+# TODO: Add hashes for other architecture toolchains as well. Make a script?
+SRC_URI[rust-std-snapshot-x86_64.sha256sum] = "36f27513a6e4381f15b0cd14097c885af537f990cb6193cec3337c429367bf23"
+SRC_URI[rustc-snapshot-x86_64.sha256sum] = "5b5d7854a0d73368f15146c1aa47e4dbccf12762c93282f410a09a605929ce09"
+SRC_URI[cargo-snapshot-x86_64.sha256sum] = "4a401dfe7b3056dc0d42acbcd380b2b90f936577706ca74ef5327af0f5abd0a0"
+
+SRC_URI[rust-std-snapshot-aarch64.sha256sum] = "41d259c6f84280fd0e7719fea03a7583ba54e33e8ac32a2a7b703ffb0aebb7d9"
+SRC_URI[rustc-snapshot-aarch64.sha256sum] = "1948a80453956d494457dcced1942e2e204fb26d4e57e718ef1c7aa378efbedb"
+SRC_URI[cargo-snapshot-aarch64.sha256sum] = "95741a4cd2073adbd74a7c5596bb912abf4b2dfe00d70a9919cba4a836b7a0ff"
+
+SRC_URI[rust-std-snapshot-powerpc64le.sha256sum] = "b6ef684ebf77063dbc1ff0abfe1316651fa73bbb95b023255b301b415867ff8b"
+SRC_URI[rustc-snapshot-powerpc64le.sha256sum] = "20ed9ec0599e6582a218dae544566ddf7e2af46341705f35de874c90d7eecc0c"
+SRC_URI[cargo-snapshot-powerpc64le.sha256sum] = "f659bf3ab70c376c736b7d7112d1fcee32a56dbfa66f6ef4fc039652f66c99e7"
+
+SRC_URI += " \
+    https://static.rust-lang.org/dist/${RUST_STD_SNAPSHOT}.tar.xz;name=rust-std-snapshot-${RUST_BUILD_ARCH};subdir=rust-snapshot-components \
+    https://static.rust-lang.org/dist/${RUSTC_SNAPSHOT}.tar.xz;name=rustc-snapshot-${RUST_BUILD_ARCH};subdir=rust-snapshot-components \
+    https://static.rust-lang.org/dist/${CARGO_SNAPSHOT}.tar.xz;name=cargo-snapshot-${RUST_BUILD_ARCH};subdir=rust-snapshot-components \
+"
+
+RUST_STD_SNAPSHOT = "rust-std-${SNAPSHOT_VERSION}-${RUST_BUILD_ARCH}-unknown-linux-gnu"
+RUSTC_SNAPSHOT = "rustc-${SNAPSHOT_VERSION}-${RUST_BUILD_ARCH}-unknown-linux-gnu"
+CARGO_SNAPSHOT = "cargo-${SNAPSHOT_VERSION}-${RUST_BUILD_ARCH}-unknown-linux-gnu"

--- a/recipes-devtools/rust/rust-source-1.73.0.inc
+++ b/recipes-devtools/rust/rust-source-1.73.0.inc
@@ -1,0 +1,7 @@
+SRC_URI += "https://static.rust-lang.org/dist/rustc-${PV}-src.tar.xz;name=rust"
+SRC_URI[rust.sha256sum] = "6eaf672dbea2e6596af8c999f5e6924b9af4bb8b02166bfe0b928e68aa75ae62"
+
+RUSTSRC = "${WORKDIR}/rustc-${PV}-src"
+
+UPSTREAM_CHECK_URI = "https://forge.rust-lang.org/infra/other-installation-methods.html"
+UPSTREAM_CHECK_REGEX = "rustc-(?P<pver>\d+(\.\d+)+)-src"

--- a/recipes-devtools/rust/rust-tools-cross-canadian_1.73.0.bb
+++ b/recipes-devtools/rust/rust-tools-cross-canadian_1.73.0.bb
@@ -1,0 +1,6 @@
+require rust-tools-cross-canadian.inc
+require rust-source-${PV}.inc
+require rust-snapshot-${PV}.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/rust:"
+

--- a/recipes-devtools/rust/rust_1.73.0.bb
+++ b/recipes-devtools/rust/rust_1.73.0.bb
@@ -1,0 +1,23 @@
+require rust-target.inc
+require rust-source-${PV}.inc
+require rust-snapshot-${PV}.inc
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=c2cccf560306876da3913d79062a54b9"
+
+INSANE_SKIP:${PN}:class-native = "already-stripped"
+
+do_compile () {
+    rust_runx build --stage 2
+}
+
+rust_do_install() {
+    rust_runx install
+}
+
+python () {
+    pn = d.getVar('PN')
+
+    if not pn.endswith("-native"):
+        raise bb.parse.SkipRecipe("Rust recipe doesn't work for target builds at this time. Fixes welcome.")
+}
+


### PR DESCRIPTION
- Bump LLVM_RELEASE to 17.0.2 (seen in github rust project `llvm-project/` submodule).
- Update default version from 1.72.0 to 1.73.0
