### PR TITLE
libstd-rs: Extend to nativesdk

### DIFF
--- a/recipes-devtools/rust/libstd-rs.inc
+++ b/recipes-devtools/rust/libstd-rs.inc
@@ -38,3 +38,5 @@ do_install () {
     rm -f ${B}/${TARGET_SYS}/${BUILD_DIR}/deps/*.d
     cp ${B}/${TARGET_SYS}/${BUILD_DIR}/deps/* ${D}${rustlibdir}
 }
+
+BBCLASSEXTEND = "nativesdk"


### PR DESCRIPTION
Allow rust standard library to be used in SDKs. This is consistent with the rust toolchain that's now included in poky.


Tested with:
```
meta-yocto-bsp       = "kirkstone:3e73216a32a2b01916eb8c555a41579bd69a47aa"
meta-oe              = "kirkstone:8a75c61cce2aa1d6e5a3597ab8fc5a7e6aeae1e4"
meta-rust            = "master:ffc33539efc3cc8cdc1dbad5c723daeb8d1d8b3b"

local.conf:
# Make poky-shipped tcmode-default.inc prefer the meta-rust version.
RUSTVERSION = "1.73.0"
# Sample inclusion of python module with rust components to SDK
TOOLCHAIN_HOST_TASK:append = " nativesdk-python3-cryptography"
```