### PR TITLE
main.yml: Use the meta-rust version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
           echo 'TOOLCHAIN_HOST_TASK:append = " packagegroup-rust-cross-canadian-${MACHINE}"' >> conf/local.conf
           echo 'PREFERRED_PROVIDER_virtual/kernel = "linux-dummy"' >> conf/local.conf
           echo 'INHERIT:remove = "uninative"' >> conf/local.conf
+          echo 'require conf/distro/include/rust_versions.inc' >> conf/local.conf
       - name: Run bitbake
         run: |
           cd poky


### PR DESCRIPTION
Noticed that in the [ci build](https://github.com/meta-rust/meta-rust/actions/runs/7144554835/job/19462276965?pr=434#step:5:903), the 1.59 versions of the toolchain are being used.

Unless set, PREFERRED_VERSION* from tcmode-default.inc will be used. Include rust_versions.inc, so the pipeline actually verifies the meta-rust versions.

Alternatively, `bitbake -r rust_versions.inc` can be used or `RUSTVERSION` (not `RUST_VERSION`) can be explicitly specified in local.conf

```
# $PREFERRED_VERSION_cargo [2 operations]
#   set? /home/riddikulus/sources/yocto/meta-rust/conf/distro/include/rust_versions.inc:6
#     "${RUST_VERSION}"
#   set? /home/riddikulus/sources/yocto/poky/meta/conf/distro/include/tcmode-default.inc:88
#     "${RUSTVERSION}"
# pre-expansion value:
#   "${RUST_VERSION}"
PREFERRED_VERSION_cargo="1.73.0"
```

