### PR TITLE
Add rust 1.75.0

### DIFF
--- a/conf/distro/include/rust_versions.inc
+++ b/conf/distro/include/rust_versions.inc
@@ -1,7 +1,7 @@
 # include this in your distribution to easily switch between versions
 # just by changing RUST_VERSION variable
 
-RUST_VERSION ?= "1.73.0"
+RUST_VERSION ?= "1.75.0"
 
 PREFERRED_VERSION_cargo ?= "${RUST_VERSION}"
 PREFERRED_VERSION_cargo-native ?= "${RUST_VERSION}"

--- a/recipes-devtools/cargo/cargo-cross-canadian_1.75.0.bb
+++ b/recipes-devtools/cargo/cargo-cross-canadian_1.75.0.bb
@@ -1,0 +1,6 @@
+require recipes-devtools/rust/rust-source-${PV}.inc
+require recipes-devtools/rust/rust-snapshot-${PV}.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/cargo-${PV}:"
+
+require cargo-cross-canadian.inc

--- a/recipes-devtools/cargo/cargo_1.75.0.bb
+++ b/recipes-devtools/cargo/cargo_1.75.0.bb
@@ -1,0 +1,4 @@
+require recipes-devtools/rust/rust-source-${PV}.inc
+require recipes-devtools/rust/rust-snapshot-${PV}.inc
+require cargo.inc
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/rust/libstd-rs_1.75.0.bb
+++ b/recipes-devtools/rust/libstd-rs_1.75.0.bb
@@ -1,0 +1,7 @@
+require rust-source-${PV}.inc
+require libstd-rs.inc
+
+LIC_FILES_CHKSUM = "file://../../COPYRIGHT;md5=c2cccf560306876da3913d79062a54b9"
+
+# libstd moved from src/libstd to library/std in 1.47+
+S = "${RUSTSRC}/library/std"

--- a/recipes-devtools/rust/rust-cross-canadian_1.75.0.bb
+++ b/recipes-devtools/rust/rust-cross-canadian_1.75.0.bb
@@ -1,0 +1,6 @@
+require rust-cross-canadian.inc
+require rust-source-${PV}.inc
+require rust-snapshot-${PV}.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/rust:"
+

--- a/recipes-devtools/rust/rust-cross_1.75.0.bb
+++ b/recipes-devtools/rust/rust-cross_1.75.0.bb
@@ -1,0 +1,6 @@
+require rust-cross.inc
+require rust-source-${PV}.inc
+
+# License file checksum needed for do_populate_lic when including a
+# Rust app in an image.
+LIC_FILES_CHKSUM="file://LICENSE-APACHE;md5=22a53954e4e0ec258dfce4391e905dac"

--- a/recipes-devtools/rust/rust-llvm_1.75.0.bb
+++ b/recipes-devtools/rust/rust-llvm_1.75.0.bb
@@ -1,0 +1,5 @@
+# check src/llvm-project/llvm/CMakeLists.txt for llvm version in use
+#
+LLVM_RELEASE = "17.0.6"
+require rust-source-${PV}.inc
+require rust-llvm.inc

--- a/recipes-devtools/rust/rust-snapshot-1.75.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.75.0.inc
@@ -1,0 +1,34 @@
+## This is information on the rust-snapshot (binary) used to build our current release.
+## snapshot info is taken from rust/src/stage0.json
+## Rust is self-hosting and bootstraps itself with a pre-built previous version of itself.
+## The exact (previous) version that has been used is specified in the source tarball.
+## The version is replicated here.
+## TODO: find a way to add additional SRC_URIs based on the contents of an
+##       earlier SRC_URI.
+
+SNAPSHOT_VERSION = "1.74.0"
+
+# TODO: Add hashes for other architecture toolchains as well.
+
+# You can use scripts/rust-get-stage0.sh to update hashes
+SRC_URI[rust-std-snapshot-x86_64.sha256sum] = "548413213012e2f62b08ed8a913a51210ae7402619027224580176031f2789ea"
+SRC_URI[rustc-snapshot-x86_64.sha256sum]    = "7d464be2ae0d6ce69f056d1ea9a8ce2b3b1d537418caea216fdd303903972181"
+SRC_URI[cargo-snapshot-x86_64.sha256sum]    = "f219386d4569c40b660518e99267afff428c13bf980bda7a614c8d4038d013f6"
+
+SRC_URI[rust-std-snapshot-aarch64.sha256sum] = "c5ad01692bc08ce6f4db2ac815be63498b45013380c71f22b3d33bf3be767270"
+SRC_URI[rustc-snapshot-aarch64.sha256sum]    = "a49bb365481913ead305658e7e9dc621da7895036b840fb57b1bc85c721d07e6"
+SRC_URI[cargo-snapshot-aarch64.sha256sum]    = "a18dc9132cf76ccba90bcbb53b56a4d37ebfb34845f61e79f7b5d4710a269647"
+
+SRC_URI[rust-std-snapshot-powerpc64le.sha256sum] = "785956d68855de18546c87d6d06cd2505cb8a10edba84327bf2b448420a31d55"
+SRC_URI[rustc-snapshot-powerpc64le.sha256sum]    = "8727b1a92e88ac1ce05198ee185dac86553edd7f50b726781c9ab64544b59809"
+SRC_URI[cargo-snapshot-powerpc64le.sha256sum]    = "2eccd404aabe5137a8e45b6173c27d08862a0e674d5866be71aff1434f271d50"
+
+SRC_URI += " \
+    https://static.rust-lang.org/dist/${RUST_STD_SNAPSHOT}.tar.xz;name=rust-std-snapshot-${RUST_BUILD_ARCH};subdir=rust-snapshot-components \
+    https://static.rust-lang.org/dist/${RUSTC_SNAPSHOT}.tar.xz;name=rustc-snapshot-${RUST_BUILD_ARCH};subdir=rust-snapshot-components \
+    https://static.rust-lang.org/dist/${CARGO_SNAPSHOT}.tar.xz;name=cargo-snapshot-${RUST_BUILD_ARCH};subdir=rust-snapshot-components \
+"
+
+RUST_STD_SNAPSHOT = "rust-std-${SNAPSHOT_VERSION}-${RUST_BUILD_ARCH}-unknown-linux-gnu"
+RUSTC_SNAPSHOT = "rustc-${SNAPSHOT_VERSION}-${RUST_BUILD_ARCH}-unknown-linux-gnu"
+CARGO_SNAPSHOT = "cargo-${SNAPSHOT_VERSION}-${RUST_BUILD_ARCH}-unknown-linux-gnu"

--- a/recipes-devtools/rust/rust-source-1.75.0.inc
+++ b/recipes-devtools/rust/rust-source-1.75.0.inc
@@ -1,5 +1,5 @@
 SRC_URI += "https://static.rust-lang.org/dist/rustc-${PV}-src.tar.xz;name=rust"
-SRC_URI[rust.sha256sum] = "6eaf672dbea2e6596af8c999f5e6924b9af4bb8b02166bfe0b928e68aa75ae62"
+SRC_URI[rust.sha256sum] = "4526f786d673e4859ff2afa0bab2ba13c918b796519a25c1acce06dba9542340"
 
 RUSTSRC = "${WORKDIR}/rustc-${PV}-src"
 

--- a/recipes-devtools/rust/rust-source-1.75.0.inc
+++ b/recipes-devtools/rust/rust-source-1.75.0.inc
@@ -1,0 +1,7 @@
+SRC_URI += "https://static.rust-lang.org/dist/rustc-${PV}-src.tar.xz;name=rust"
+SRC_URI[rust.sha256sum] = "6eaf672dbea2e6596af8c999f5e6924b9af4bb8b02166bfe0b928e68aa75ae62"
+
+RUSTSRC = "${WORKDIR}/rustc-${PV}-src"
+
+UPSTREAM_CHECK_URI = "https://forge.rust-lang.org/infra/other-installation-methods.html"
+UPSTREAM_CHECK_REGEX = "rustc-(?P<pver>\d+(\.\d+)+)-src"

--- a/recipes-devtools/rust/rust-tools-cross-canadian_1.75.0.bb
+++ b/recipes-devtools/rust/rust-tools-cross-canadian_1.75.0.bb
@@ -1,0 +1,6 @@
+require rust-tools-cross-canadian.inc
+require rust-source-${PV}.inc
+require rust-snapshot-${PV}.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/rust:"
+

--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -144,11 +144,12 @@ python do_configure() {
     config.add_section("install")
     # ./x.py install doesn't have any notion of "destdir"
     # but we can prepend ${D} to all the directories instead
-    config.set("install", "prefix",  e(d.getVar("D", True) + d.getVar("prefix", True)))
-    config.set("install", "bindir",  e(d.getVar("D", True) + d.getVar("bindir", True)))
-    config.set("install", "libdir",  e(d.getVar("D", True) + d.getVar("libdir", True)))
-    config.set("install", "datadir", e(d.getVar("D", True) + d.getVar("datadir", True)))
-    config.set("install", "mandir",  e(d.getVar("D", True) + d.getVar("mandir", True)))
+    config.set("install", "prefix",     e(d.getVar("D", True) + d.getVar("prefix", True)))
+    config.set("install", "bindir",     e(d.getVar("D", True) + d.getVar("bindir", True)))
+    config.set("install", "libdir",     e(d.getVar("D", True) + d.getVar("libdir", True)))
+    config.set("install", "datadir",    e(d.getVar("D", True) + d.getVar("datadir", True)))
+    config.set("install", "mandir",     e(d.getVar("D", True) + d.getVar("mandir", True)))
+    config.set("install", "sysconfdir", e(d.getVar("D", True) + d.getVar("sysconfdir", True)))
 
     with open("config.toml", "w") as f:
         f.write('changelog-seen = 2\n\n')

--- a/recipes-devtools/rust/rust_1.75.0.bb
+++ b/recipes-devtools/rust/rust_1.75.0.bb
@@ -1,0 +1,23 @@
+require rust-target.inc
+require rust-source-${PV}.inc
+require rust-snapshot-${PV}.inc
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=c2cccf560306876da3913d79062a54b9"
+
+INSANE_SKIP:${PN}:class-native = "already-stripped"
+
+do_compile () {
+    rust_runx build --stage 2
+}
+
+rust_do_install() {
+    rust_runx install
+}
+
+python () {
+    pn = d.getVar('PN')
+
+    if not pn.endswith("-native"):
+        raise bb.parse.SkipRecipe("Rust recipe doesn't work for target builds at this time. Fixes welcome.")
+}
+

--- a/scripts/rust-get-stage0.sh
+++ b/scripts/rust-get-stage0.sh
@@ -76,4 +76,8 @@ jq .checksums_sha256 <"${OUT}" | grep "cargo-${STAGE0_RUST_VERSION}-powerpc64le-
 printf -- "\n"
 
 
+
+printf -- "Do not forget to update hash for rust-source in 'recipes-devtools/rust/rust-source-%s.inc'\n" "${RUST_VERSION}"
+
+
 rm "${OUT}"

--- a/scripts/rust-get-stage0.sh
+++ b/scripts/rust-get-stage0.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+#
+# This script helps to update rust version by taking sha256sum from stage0.json
+# (For updating recipes-devtool/rust/rust-snapshot-${RUST_VERSION}.inc)
+#
+# Stage0 url :
+# https://raw.githubusercontent.com/rust-lang/rust/${RUST_VERSION}/src/stage0.json
+#
+# Dependency on "jq" shell tools for Json parsing.
+##
+# Usage :
+#  ./rust-get-stage0.sh <Rust_version>
+# ex: ./rust-get-stage0.sh 1.75.0
+
+set -u
+set -e
+
+RUST_VERSION="${1:-1.75.0}"
+
+OUT="$(mktemp --suffix=_stage0.json)"
+
+printf -- "Get stage0.json for rust version %s\n" "${RUST_VERSION}"
+
+# Get Stage0
+curl -s -S --header "Accept: application/json" \
+    "https://raw.githubusercontent.com/rust-lang/rust/${RUST_VERSION}/src/stage0.json" \
+    -o "${OUT}"
+
+STAGE0_RUST_VERSION=$(jq -r .compiler.version <"${OUT}")
+printf -- "Compiler version for stage0 is : %s\n" "${STAGE0_RUST_VERSION}"
+
+
+# x86_64-unknown-linux-gnu
+printf -- "Hashes (sha256sum) for x86_64-unknow-linux-gnu.tar.xz snapshot\n"
+
+printf -- "- rust-std-%s-x86_64-unknown-linux-gnu.tar.xz\n" "${STAGE0_RUST_VERSION}"
+jq .checksums_sha256 <"${OUT}" | grep "rust-std-${STAGE0_RUST_VERSION}-x86_64-unknown-linux-gnu.tar.xz"
+printf -- "\n"
+
+printf -- "- rustc-%s-x86_64-unknown-linux-gnu.tar.xz\n" "${STAGE0_RUST_VERSION}"
+jq .checksums_sha256 <"${OUT}" | grep "rustc-${STAGE0_RUST_VERSION}-x86_64-unknown-linux-gnu.tar.xz"
+printf -- "\n"
+
+printf -- "- cargo-%s-x86_64-unknown-linux-gnu.tar.xz\n" "${STAGE0_RUST_VERSION}"
+jq .checksums_sha256 <"${OUT}" | grep "cargo-${STAGE0_RUST_VERSION}-x86_64-unknown-linux-gnu.tar.xz"
+printf -- "\n"
+
+
+# aarch64-unknown-linux-gnu
+printf -- "Hashes (sha256sum) for aarch64-unknown-linux-gnu snapshot\n"
+
+printf -- "- rust-std-%s-aarch64-unknown-linux-gnu.tar.xz\n" "${STAGE0_RUST_VERSION}"
+jq .checksums_sha256 <"${OUT}" | grep "rust-std-${STAGE0_RUST_VERSION}-aarch64-unknown-linux-gnu.tar.xz"
+printf -- "\n"
+
+printf -- "- rustc-%s-aarch64-unknown-linux-gnu.tar.xz\n" "${STAGE0_RUST_VERSION}"
+jq .checksums_sha256 <"${OUT}" | grep "rustc-${STAGE0_RUST_VERSION}-aarch64-unknown-linux-gnu.tar.xz"
+printf -- "\n"
+
+printf -- "- cargo-%s-aarch64-unknown-linux-gnu.tar.xz\n" "${STAGE0_RUST_VERSION}"
+jq .checksums_sha256 <"${OUT}" | grep "cargo-${STAGE0_RUST_VERSION}-aarch64-unknown-linux-gnu.tar.xz"
+printf -- "\n"
+
+
+# powerpc64le-unknown-linux-gnu
+printf -- "Hashes (sha256sum) for powerpc64le snapshot\n"
+
+printf -- "- rust-std-%s-powerpc64le-unknown-linux-gnu.tar.xz\n" "${STAGE0_RUST_VERSION}"
+jq .checksums_sha256 <"${OUT}" | grep "rust-std-${STAGE0_RUST_VERSION}-powerpc64le-unknown-linux-gnu.tar.xz"
+printf -- "\n"
+printf -- "- rustc-%s-powerpc64le-unknown-linux-gnu.tar.xz\n" "${STAGE0_RUST_VERSION}"
+jq .checksums_sha256 <"${OUT}" | grep "rustc-${STAGE0_RUST_VERSION}-powerpc64le-unknown-linux-gnu.tar.xz"
+printf -- "\n"
+printf -- "- cargo-%s-powerpc64le-unknown-linux-gnu.tar.xz\n" "${STAGE0_RUST_VERSION}"
+jq .checksums_sha256 <"${OUT}" | grep "cargo-${STAGE0_RUST_VERSION}-powerpc64le-unknown-linux-gnu.tar.xz"
+printf -- "\n"
+
+
+rm "${OUT}"


### PR DESCRIPTION
Integrate rust 1.75.0 and fixes recipes rust.inc with missing sysconfdir in config.toml.

Also add a minimal shell script which use `jq` to get directly the `stage0.json` from rust github to help update tarball hashes (But do not update recipe directly for now)

Note: Tested on yocto kirkstone.