### PR TITLE
Fix incorrect target json for armv8 / aarch64-poky-linux

### DIFF
--- a/recipes-devtools/rust/rust-common.inc
+++ b/recipes-devtools/rust/rust-common.inc
@@ -35,7 +35,7 @@ def llvm_features_from_tune(d):
 
     if 'neon' in feat:
         f.append("+neon")
-    else:
+    elif target_is_armv7(d):
         f.append("-neon")
 
     if ('armv6' in mach_overrides) or ('armv6' in feat):


### PR DESCRIPTION
As seen in https://github.com/briansmith/ring/issues/1873, targeting aarch64-poky-linux may not always explicitly have neon in TUNE_FEATURES, but it should also not be removed because it's... there.

With OECore's rust build that works because it's only marked as absent for armv7:

https://github.com/openembedded/openembedded-core/blob/97b5d0c85af0b667854eea90ace0a8c2f51ecefe/meta/classes-recipe/rust-target-config.bbclass#L32

So apply the same here.