### PR TITLE
rust-common: Update data layout for armv7-unknown-linux-gnueabihf

### DIFF
--- a/recipes-devtools/rust/rust-common.inc
+++ b/recipes-devtools/rust/rust-common.inc
@@ -121,7 +121,7 @@ def llvm_features(d):
 
 
 ## arm-unknown-linux-gnueabihf
-DATA_LAYOUT[arm-eabi] = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
+DATA_LAYOUT[arm-eabi] = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
 LLVM_TARGET[arm-eabi] = "${RUST_TARGET_SYS}"
 TARGET_ENDIAN[arm-eabi] = "little"
 TARGET_POINTER_WIDTH[arm-eabi] = "32"
@@ -130,7 +130,7 @@ MAX_ATOMIC_WIDTH[arm-eabi] = "64"
 FEATURES[arm-eabi] = "+v6,+vfp2"
 
 ## armv7-unknown-linux-gnueabihf
-DATA_LAYOUT[armv7-eabi] = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
+DATA_LAYOUT[armv7-eabi] = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
 LLVM_TARGET[armv7-eabi] = "${RUST_TARGET_SYS}"
 TARGET_ENDIAN[armv7-eabi] = "little"
 TARGET_POINTER_WIDTH[armv7-eabi] = "32"

--- a/recipes-devtools/rust/rust-common.inc
+++ b/recipes-devtools/rust/rust-common.inc
@@ -378,4 +378,11 @@ python do_rust_gen_targets () {
 
 addtask rust_gen_targets after do_patch before do_compile
 do_rust_gen_targets[dirs] += "${WORKDIR}/targets"
-
+do_rust_gen_targets[vardeps] += "\
+    LLVM_TARGET \
+    DATA_LAYOUT \
+    MAX_ATOMIC_WIDTH \
+    TARGET_POINTER_WIDTH \
+    TARGET_C_INT_WIDTH \
+    TARGET_ENDIAN \
+"


### PR DESCRIPTION
Akin to b93853c, update the data layout to fix the following build error:

error: data-layout for target `arm-poky-linux-gnueabi`, `e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64`, differs from LLVM target's `armv7-unknown-linux-gnueabihf` default layout, `e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64`

Fixes #444.

~Note that even a rebuild of the Rust toolchain doesn't seem to make this change take effect in an existing Yocto setup. My assumption is that the rust_gen_target function is cached somehow. To fix a build that had this error previously, that function may need to be changed to trigger Yocto to actually generate the correct target JSON file, e.g. by adding a simple log statement. See issue #444 for more information.~

The second commit should address the issue discussed in #444, where changing the data layout didn't actually have any effect. An alternative would be to force a rerun of the `do_rust_gen_targets` task for any and all recipes that fail to compile.