### PR TITLE
cargo_common: Exclude http_proxy from variable dependencies

### DIFF
--- a/classes/cargo_common.bbclass
+++ b/classes/cargo_common.bbclass
@@ -105,6 +105,7 @@ cargo_common_do_configure () {
 	progress.width = 80
 	EOF
 }
+cargo_common_do_configure[vardepsexclude] += "http_proxy"
 
 oe_cargo_fix_env () {
 	export CC="${RUST_TARGET_CC}"


### PR DESCRIPTION
The value of `http_proxy` does not affect the build output and as such should be excluded from the task's hash to avoid sstate cache misses on build hosts with different `http_proxy` settings.