### PR TITLE
Rust 1.82

### DIFF
--- a/recipes-devtools/cargo/cargo-cross-canadian_1.82.0.bb
+++ b/recipes-devtools/cargo/cargo-cross-canadian_1.82.0.bb
@@ -1,0 +1,6 @@
+require recipes-devtools/rust/rust-source-${PV}.inc
+require recipes-devtools/rust/rust-snapshot-${PV}.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/cargo-${PV}:"
+
+require cargo-cross-canadian.inc

--- a/recipes-devtools/cargo/cargo_1.82.0.bb
+++ b/recipes-devtools/cargo/cargo_1.82.0.bb
@@ -1,0 +1,4 @@
+require recipes-devtools/rust/rust-source-${PV}.inc
+require recipes-devtools/rust/rust-snapshot-${PV}.inc
+require cargo.inc
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/rust/libstd-rs_1.82.0.bb
+++ b/recipes-devtools/rust/libstd-rs_1.82.0.bb
@@ -1,0 +1,7 @@
+require rust-source-${PV}.inc
+require libstd-rs.inc
+
+LIC_FILES_CHKSUM = "file://../../COPYRIGHT;md5=c2cccf560306876da3913d79062a54b9"
+
+# libstd moved from src/libstd to library/std in 1.47+
+S = "${RUSTSRC}/library/std"

--- a/recipes-devtools/rust/rust-cross-canadian_1.82.0.bb
+++ b/recipes-devtools/rust/rust-cross-canadian_1.82.0.bb
@@ -1,0 +1,6 @@
+require rust-cross-canadian.inc
+require rust-source-${PV}.inc
+require rust-snapshot-${PV}.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/rust:"
+

--- a/recipes-devtools/rust/rust-cross_1.82.0.bb
+++ b/recipes-devtools/rust/rust-cross_1.82.0.bb
@@ -1,0 +1,6 @@
+require rust-cross.inc
+require rust-source-${PV}.inc
+
+# License file checksum needed for do_populate_lic when including a
+# Rust app in an image.
+LIC_FILES_CHKSUM="file://LICENSE-APACHE;md5=22a53954e4e0ec258dfce4391e905dac"

--- a/recipes-devtools/rust/rust-crosssdk_1.82.0.bb
+++ b/recipes-devtools/rust/rust-crosssdk_1.82.0.bb
@@ -1,0 +1,6 @@
+require rust-crosssdk.inc
+require rust-source-${PV}.inc
+
+# License file checksum needed for do_populate_lic when including a
+# Rust app in an image.
+LIC_FILES_CHKSUM="file://LICENSE-APACHE;md5=22a53954e4e0ec258dfce4391e905dac"

--- a/recipes-devtools/rust/rust-llvm_1.82.0.bb
+++ b/recipes-devtools/rust/rust-llvm_1.82.0.bb
@@ -1,0 +1,5 @@
+# check src/llvm-project/cmake/modules/LLVMVersion.cmake for llvm version in use
+#
+LLVM_RELEASE = "19.1.1"
+require rust-source-${PV}.inc
+require rust-llvm.inc

--- a/recipes-devtools/rust/rust-snapshot-1.82.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.82.0.inc
@@ -1,0 +1,34 @@
+## This is information on the rust-snapshot (binary) used to build our current release.
+## snapshot info is taken from rust/src/stage0
+## Rust is self-hosting and bootstraps itself with a pre-built previous version of itself.
+## The exact (previous) version that has been used is specified in the source tarball.
+## The version is replicated here.
+## TODO: find a way to add additional SRC_URIs based on the contents of an
+##       earlier SRC_URI.
+
+SNAPSHOT_VERSION = "1.81.0"
+
+# TODO: Add hashes for other architecture toolchains as well.
+
+# You can use scripts/rust-get-stage0.sh to update hashes
+SRC_URI[rust-std-snapshot-x86_64.sha256sum] = "6ddf80f254e8eea9956308ba89fd68e1ac7885853df9239b07bbc9f047b7562f"
+SRC_URI[rustc-snapshot-x86_64.sha256sum]    = "988a4e4cdecebe4f4a0c52ec4ade5a5bfc58d6958969f5b1e8aac033bda2613e"
+SRC_URI[cargo-snapshot-x86_64.sha256sum]    = "c50ee4b1ae8695461930e36d5465dddb7c7a0e0f0aa6cbd60de120b17c38b841"
+
+SRC_URI[rust-std-snapshot-aarch64.sha256sum] = "85567f037cee338f8ec8f9b6287a7f200d221658a996cba254abc91606ece6f4"
+SRC_URI[rustc-snapshot-aarch64.sha256sum]    = "301f651f38f8c52ebaad0ac7eb211a5ea25c3b690686d1c265febeee62d2c6fc"
+SRC_URI[cargo-snapshot-aarch64.sha256sum]    = "76f8927e4923c26c51b60ef99a29f3609843b3a2730f0bdf2ea6958626f11b11"
+
+SRC_URI[rust-std-snapshot-powerpc64le.sha256sum] = "5ba237cfbd18806bf77fbe8bc31b14a17f3d14acb30a022955cf047eb8d41056"
+SRC_URI[rustc-snapshot-powerpc64le.sha256sum]    = "734f407345b05617d62a30d96d8305b51b7cf7de3b1bdc160449726ea8f51ae0"
+SRC_URI[cargo-snapshot-powerpc64le.sha256sum]    = "813d2dcd603a1ad65a5de77515f4c94fdae301a1e1e8afcc2541076eebaba848"
+
+SRC_URI += " \
+    https://static.rust-lang.org/dist/${RUST_STD_SNAPSHOT}.tar.xz;name=rust-std-snapshot-${RUST_BUILD_ARCH};subdir=rust-snapshot-components \
+    https://static.rust-lang.org/dist/${RUSTC_SNAPSHOT}.tar.xz;name=rustc-snapshot-${RUST_BUILD_ARCH};subdir=rust-snapshot-components \
+    https://static.rust-lang.org/dist/${CARGO_SNAPSHOT}.tar.xz;name=cargo-snapshot-${RUST_BUILD_ARCH};subdir=rust-snapshot-components \
+"
+
+RUST_STD_SNAPSHOT = "rust-std-${SNAPSHOT_VERSION}-${RUST_BUILD_ARCH}-unknown-linux-gnu"
+RUSTC_SNAPSHOT = "rustc-${SNAPSHOT_VERSION}-${RUST_BUILD_ARCH}-unknown-linux-gnu"
+CARGO_SNAPSHOT = "cargo-${SNAPSHOT_VERSION}-${RUST_BUILD_ARCH}-unknown-linux-gnu"

--- a/recipes-devtools/rust/rust-source-1.82.0.inc
+++ b/recipes-devtools/rust/rust-source-1.82.0.inc
@@ -1,0 +1,7 @@
+SRC_URI += "https://static.rust-lang.org/dist/rustc-${PV}-src.tar.xz;name=rust"
+SRC_URI[rust.sha256sum] = "1276a0bb8fa12288ba6fa96597d28b40e74c44257c051d3bc02c2b049bb38210"
+
+RUSTSRC = "${WORKDIR}/rustc-${PV}-src"
+
+UPSTREAM_CHECK_URI = "https://forge.rust-lang.org/infra/other-installation-methods.html"
+UPSTREAM_CHECK_REGEX = "rustc-(?P<pver>\d+(\.\d+)+)-src"

--- a/recipes-devtools/rust/rust-tools-cross-canadian_1.82.0.bb
+++ b/recipes-devtools/rust/rust-tools-cross-canadian_1.82.0.bb
@@ -1,0 +1,6 @@
+require rust-tools-cross-canadian.inc
+require rust-source-${PV}.inc
+require rust-snapshot-${PV}.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/rust:"
+

--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -152,7 +152,10 @@ python do_configure() {
     config.set("install", "sysconfdir", e(d.getVar("D", True) + d.getVar("sysconfdir", True)))
 
     with open("config.toml", "w") as f:
-        f.write('changelog-seen = 2\n\n')
+        if bb.utils.vercmp_string_op(d.getVar("RUST_VERSION", True), "1.80.0", "<"):
+            f.write('changelog-seen = 2\n\n')
+        elif bb.utils.vercmp_string_op(d.getVar("RUST_VERSION", True), "1.82.0", "<="):
+            f.write('change-id = 115898\n\n')
         config.write(f)
 
     # set up ${WORKDIR}/cargo_home

--- a/recipes-devtools/rust/rust_1.82.0.bb
+++ b/recipes-devtools/rust/rust_1.82.0.bb
@@ -1,0 +1,23 @@
+require rust-target.inc
+require rust-source-${PV}.inc
+require rust-snapshot-${PV}.inc
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=c2cccf560306876da3913d79062a54b9"
+
+INSANE_SKIP:${PN}:class-native = "already-stripped"
+
+do_compile () {
+    rust_runx build --stage 2
+}
+
+rust_do_install() {
+    rust_runx install
+}
+
+python () {
+    pn = d.getVar('PN')
+
+    if not pn.endswith("-native"):
+        raise bb.parse.SkipRecipe("Rust recipe doesn't work for target builds at this time. Fixes welcome.")
+}
+


### PR DESCRIPTION
This necessitated some more changes than a normal update, since `changelog-seen` is for older version. The added support for `change-id` is split into a separate commit. The only info I have been able to find online is from was from the [Chromium issue tracker](https://issues.chromium.org/issues/335782507)