### PR TITLE
Fix devshell can't work

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -107,4 +107,9 @@ cargo_do_install () {
 	fi
 }
 
+python do_devshell:prepend () {
+    os.environ['RUSTFLAGS'] = d.getVar('RUSTFLAGS')
+    os.environ['CARGO_BUILD_TARGET'] = d.getVar('HOST_SYS')
+}
+
 EXPORT_FUNCTIONS do_compile do_install


### PR DESCRIPTION
Export RUSTFLAGS and CARGO_BUILD_TARGET to devshell, 
then can use `bitbake -c devshell recipe` to  enter into devshell, and use cargo build to build directly.

https://doc.rust-lang.org/cargo/reference/config.html#buildtarget