### PR TITLE
Fix missing proc_macro for libstd-rs 1.82.0

### DIFF
--- a/recipes-devtools/rust/libstd-rs_1.82.0.bb
+++ b/recipes-devtools/rust/libstd-rs_1.82.0.bb
@@ -3,5 +3,5 @@ require libstd-rs.inc
 
 LIC_FILES_CHKSUM = "file://../../COPYRIGHT;md5=c2cccf560306876da3913d79062a54b9"
 
-# libstd moved from src/libstd to library/std in 1.47+
-S = "${RUSTSRC}/library/std"
+# libstd moved from src/std to library/sysroot in 1.72+
+S = "${RUSTSRC}/library/sysroot"


### PR DESCRIPTION
| error[E0463]: can't find crate for `proc_macro`
|   --> /usr/src/debug/pocket/0.1.0.AUTOINC+e82af10ec8-r0/cargo_home/bitbake/proc-macro2-1.0.6/src/lib.rs:86:1
|    |
| 86 | extern crate proc_macro;
|    | ^^^^^^^^^^^^^^^^^^^^^^^^ can't find crate