### PR TITLE
conf/layer.conf: add langdale to layer compat

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ jobs:
       matrix:
         branch:
           - {distro: kirkstone, version: 4.0.1}
+          - {distro: langdale, version: 4.1.4}
           - {distro: mickledore, version: 4.2.2}
     env:
       YOCTO_VERSION: ${{ matrix.branch.version }}

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_PATTERN_rust-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_rust-layer = "7"
 
 LAYERDEPENDS_rust-layer = "core openembedded-layer"
-LAYERSERIES_COMPAT_rust-layer = "gatesgarth hardknott honister kirkstone mickledore"
+LAYERSERIES_COMPAT_rust-layer = "gatesgarth hardknott honister kirkstone langdale mickledore"
 
 # Override security flags
 require conf/distro/include/rust_security_flags.inc


### PR DESCRIPTION
Given this is my first contribution to this project please let me know if this PR or the commits are missing anything that is required.

Comments: 

- NOTE: "langdale" may not be an LTS release, but it is used by certain BSP vendors (such as Xilinx 2024.1).
- WARN: This will likely trigger a merge conflict with the following PR (https://github.com/meta-rust/meta-rust/pull/462).
- NOTE: My fork currently contains a new "langdale" branch at this commit for testing.

Questions:

1. Would it be preferred to push a separate branch named "langdale" and then have this PR be merged into that branch instead?
2. Would it be preferred to branch from an earlier commit, perhaps before or after the commit that added mickledore (https://github.com/meta-rust/meta-rust/pull/423, https://github.com/meta-rust/meta-rust/commits/13e4e8f43c900e686df42038e9b92ac98cc705a6)?
3. If this is merged into master would you be willing to push a "langdale" branch to point to the merge commit?