### PR TITLE
Rust 1.86.0

### DIFF
--- a/conf/distro/include/rust_versions.inc
+++ b/conf/distro/include/rust_versions.inc
@@ -1,7 +1,7 @@
 # include this in your distribution to easily switch between versions
 # just by changing RUST_VERSION variable
 
-RUST_VERSION ?= "1.78.0"
+RUST_VERSION ?= "1.86.0"
 
 PREFERRED_VERSION_cargo ?= "${RUST_VERSION}"
 PREFERRED_VERSION_cargo-cross-canadian-${TARGET_ARCH} ?= "${RUST_VERSION}"

--- a/recipes-devtools/cargo/cargo-cross-canadian_1.86.0.bb
+++ b/recipes-devtools/cargo/cargo-cross-canadian_1.86.0.bb
@@ -1,0 +1,6 @@
+require recipes-devtools/rust/rust-source-${PV}.inc
+require recipes-devtools/rust/rust-snapshot-${PV}.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/cargo-${PV}:"
+
+require cargo-cross-canadian.inc

--- a/recipes-devtools/cargo/cargo_1.86.0.bb
+++ b/recipes-devtools/cargo/cargo_1.86.0.bb
@@ -1,0 +1,4 @@
+require recipes-devtools/rust/rust-source-${PV}.inc
+require recipes-devtools/rust/rust-snapshot-${PV}.inc
+require cargo.inc
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/rust/libstd-rs_1.86.0.bb
+++ b/recipes-devtools/rust/libstd-rs_1.86.0.bb
@@ -1,0 +1,7 @@
+require rust-source-${PV}.inc
+require libstd-rs.inc
+
+LIC_FILES_CHKSUM = "file://../../COPYRIGHT;md5=c2cccf560306876da3913d79062a54b9"
+
+# libstd moved from src/libstd to library/std in 1.47+
+S = "${RUSTSRC}/library/std"

--- a/recipes-devtools/rust/libstd-rs_1.86.0.bb
+++ b/recipes-devtools/rust/libstd-rs_1.86.0.bb
@@ -5,3 +5,6 @@ LIC_FILES_CHKSUM = "file://../../COPYRIGHT;md5=11a3899825f4376896e438c8c753f8dc"
 
 # libstd moved from src/libstd to library/std in 1.47+
 S = "${RUSTSRC}/library/std"
+
+# ref: https://github.com/rust-lang/rust/issues/133857
+RUSTFLAGS += "-Zforce-unstable-if-unmarked"

--- a/recipes-devtools/rust/libstd-rs_1.86.0.bb
+++ b/recipes-devtools/rust/libstd-rs_1.86.0.bb
@@ -1,7 +1,7 @@
 require rust-source-${PV}.inc
 require libstd-rs.inc
 
-LIC_FILES_CHKSUM = "file://../../COPYRIGHT;md5=c2cccf560306876da3913d79062a54b9"
+LIC_FILES_CHKSUM = "file://../../COPYRIGHT;md5=11a3899825f4376896e438c8c753f8dc"
 
 # libstd moved from src/libstd to library/std in 1.47+
 S = "${RUSTSRC}/library/std"

--- a/recipes-devtools/rust/rust-cross-canadian_1.86.0.bb
+++ b/recipes-devtools/rust/rust-cross-canadian_1.86.0.bb
@@ -1,0 +1,6 @@
+require rust-cross-canadian.inc
+require rust-source-${PV}.inc
+require rust-snapshot-${PV}.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/rust:"
+

--- a/recipes-devtools/rust/rust-cross_1.86.0.bb
+++ b/recipes-devtools/rust/rust-cross_1.86.0.bb
@@ -1,0 +1,6 @@
+require rust-cross.inc
+require rust-source-${PV}.inc
+
+# License file checksum needed for do_populate_lic when including a
+# Rust app in an image.
+LIC_FILES_CHKSUM="file://LICENSE-APACHE;md5=22a53954e4e0ec258dfce4391e905dac"

--- a/recipes-devtools/rust/rust-crosssdk_1.86.0.bb
+++ b/recipes-devtools/rust/rust-crosssdk_1.86.0.bb
@@ -1,0 +1,6 @@
+require rust-crosssdk.inc
+require rust-source-${PV}.inc
+
+# License file checksum needed for do_populate_lic when including a
+# Rust app in an image.
+LIC_FILES_CHKSUM="file://LICENSE-APACHE;md5=22a53954e4e0ec258dfce4391e905dac"

--- a/recipes-devtools/rust/rust-llvm_1.86.0.bb
+++ b/recipes-devtools/rust/rust-llvm_1.86.0.bb
@@ -1,0 +1,5 @@
+# check src/llvm-project/cmake/modules/LLVMVersion.cmake for llvm version in use
+#
+LLVM_RELEASE = "19.1.7"
+require rust-source-${PV}.inc
+require rust-llvm.inc

--- a/recipes-devtools/rust/rust-snapshot-1.86.0.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.86.0.inc
@@ -1,0 +1,34 @@
+## This is information on the rust-snapshot (binary) used to build our current release.
+## snapshot info is taken from rust/src/stage0
+## Rust is self-hosting and bootstraps itself with a pre-built previous version of itself.
+## The exact (previous) version that has been used is specified in the source tarball.
+## The version is replicated here.
+## TODO: find a way to add additional SRC_URIs based on the contents of an
+##       earlier SRC_URI.
+
+SNAPSHOT_VERSION = "1.85.0"
+
+# TODO: Add hashes for other architecture toolchains as well.
+
+# You can use scripts/rust-get-stage0.sh to update hashes
+SRC_URI[rust-std-snapshot-x86_64.sha256sum] = "285e105d25ebdf501341238d4c0594ecdda50ec9078f45095f793a736b1f1ac2"
+SRC_URI[rustc-snapshot-x86_64.sha256sum] = "7436f13797475082cd87aa65547449e01659d6a810b4cd5f8aedc48bb9f89dfb"
+SRC_URI[cargo-snapshot-x86_64.sha256sum] = "0aff33b57b0e0b102d762a2b53042846c1ca346cff4b7bd96b5c03c9e8e51d81"
+
+SRC_URI[rust-std-snapshot-aarch64.sha256sum] = "8af1d793f7820e9ad0ee23247a9123542c3ea23f8857a018651c7788af9bc5b7"
+SRC_URI[rustc-snapshot-aarch64.sha256sum] = "e742b768f67303010b002b515f6613c639e69ffcc78cd0857d6fe7989e9880f6"
+SRC_URI[cargo-snapshot-aarch64.sha256sum] = "cdebe48b066d512d664c13441e8fae2d0f67106c2080aa44289d98b24192b8bc"
+
+SRC_URI[rust-std-snapshot-powerpc64le.sha256sum] = "d0cfda4e18623d17922eb367e44ac9549ab3d5fe1c0bdbe0c2c95754255fa705"
+SRC_URI[rustc-snapshot-powerpc64le.sha256sum] = "371e40f9d6d82aecb056f70f82868d98ddc1c20510aa7d388442ac8d2d86a6ca"
+SRC_URI[cargo-snapshot-powerpc64le.sha256sum] = "e1469f4249a7e21f872af487dcd1bd10ce388b5b3679bdab0cb0965e1e30fe47"
+
+SRC_URI += " \
+    https://static.rust-lang.org/dist/${RUST_STD_SNAPSHOT}.tar.xz;name=rust-std-snapshot-${RUST_BUILD_ARCH};subdir=rust-snapshot-components \
+    https://static.rust-lang.org/dist/${RUSTC_SNAPSHOT}.tar.xz;name=rustc-snapshot-${RUST_BUILD_ARCH};subdir=rust-snapshot-components \
+    https://static.rust-lang.org/dist/${CARGO_SNAPSHOT}.tar.xz;name=cargo-snapshot-${RUST_BUILD_ARCH};subdir=rust-snapshot-components \
+"
+
+RUST_STD_SNAPSHOT = "rust-std-${SNAPSHOT_VERSION}-${RUST_BUILD_ARCH}-unknown-linux-gnu"
+RUSTC_SNAPSHOT = "rustc-${SNAPSHOT_VERSION}-${RUST_BUILD_ARCH}-unknown-linux-gnu"
+CARGO_SNAPSHOT = "cargo-${SNAPSHOT_VERSION}-${RUST_BUILD_ARCH}-unknown-linux-gnu"

--- a/recipes-devtools/rust/rust-source-1.86.0.inc
+++ b/recipes-devtools/rust/rust-source-1.86.0.inc
@@ -1,0 +1,7 @@
+SRC_URI += "https://static.rust-lang.org/dist/rustc-${PV}-src.tar.xz;name=rust"
+SRC_URI[rust.sha256sum] = "d939eada065dc827a9d4dbb55bd48533ad14c16e7f0a42e70147029c82a7707b"
+
+RUSTSRC = "${WORKDIR}/rustc-${PV}-src"
+
+UPSTREAM_CHECK_URI = "https://forge.rust-lang.org/infra/other-installation-methods.html"
+UPSTREAM_CHECK_REGEX = "rustc-(?P<pver>\d+(\.\d+)+)-src"

--- a/recipes-devtools/rust/rust-tools-cross-canadian_1.86.0.bb
+++ b/recipes-devtools/rust/rust-tools-cross-canadian_1.86.0.bb
@@ -1,0 +1,6 @@
+require rust-tools-cross-canadian.inc
+require rust-source-${PV}.inc
+require rust-snapshot-${PV}.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/rust:"
+

--- a/recipes-devtools/rust/rust_1.86.0.bb
+++ b/recipes-devtools/rust/rust_1.86.0.bb
@@ -1,0 +1,23 @@
+require rust-target.inc
+require rust-source-${PV}.inc
+require rust-snapshot-${PV}.inc
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=c2cccf560306876da3913d79062a54b9"
+
+INSANE_SKIP:${PN}:class-native = "already-stripped"
+
+do_compile () {
+    rust_runx build --stage 2
+}
+
+rust_do_install() {
+    rust_runx install
+}
+
+python () {
+    pn = d.getVar('PN')
+
+    if not pn.endswith("-native"):
+        raise bb.parse.SkipRecipe("Rust recipe doesn't work for target builds at this time. Fixes welcome.")
+}
+

--- a/recipes-devtools/rust/rust_1.86.0.bb
+++ b/recipes-devtools/rust/rust_1.86.0.bb
@@ -2,7 +2,7 @@ require rust-target.inc
 require rust-source-${PV}.inc
 require rust-snapshot-${PV}.inc
 
-LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=c2cccf560306876da3913d79062a54b9"
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=11a3899825f4376896e438c8c753f8dc"
 
 INSANE_SKIP:${PN}:class-native = "already-stripped"
 

--- a/recipes-devtools/rust/rust_1.86.0.bb
+++ b/recipes-devtools/rust/rust_1.86.0.bb
@@ -6,6 +6,8 @@ LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=11a3899825f4376896e438c8c753f8dc"
 
 INSANE_SKIP:${PN}:class-native = "already-stripped"
 
+DEPENDS += "ninja-native"
+
 do_compile () {
     rust_runx build --stage 2
 }

--- a/scripts/rust-get-stage0.sh
+++ b/scripts/rust-get-stage0.sh
@@ -3,10 +3,17 @@
 # This script helps to update rust version by taking sha256sum from stage0.json
 # (For updating recipes-devtool/rust/rust-snapshot-${RUST_VERSION}.inc)
 #
-# Stage0 url :
+# Before version 1.80, stage0 was a json file
+# parsing was done using jq.
+# Starting from 1.80.x stage0 is a plain text file with key=value.
+#
+# RUST_VERSION < 1.80.0 : Stage0 url :
 # https://raw.githubusercontent.com/rust-lang/rust/${RUST_VERSION}/src/stage0.json
 #
-# Dependency on "jq" shell tools for Json parsing.
+# RUST_VERSION >= 1.80.0 : Stage0 url :
+# https://raw.githubusercontent.com/rust-lang/rust/${RUST_VERSION}/src/stage0
+#
+# Dependency on "jq" shell tools for Json parsing before RUST_VERSION 1.80.0
 ##
 # Usage :
 #  ./rust-get-stage0.sh <Rust_version>
@@ -15,69 +22,163 @@
 set -u
 set -e
 
-RUST_VERSION="${1:-1.75.0}"
+RUST_VERSION="${1:-1.83.0}"
 
-OUT="$(mktemp --suffix=_stage0.json)"
 
-printf -- "Get stage0.json for rust version %s\n" "${RUST_VERSION}"
+SUPPORTED_ARCH=" \
+    x86_64-unknown-linux-gnu \
+    aarch64-unknown-linux-gnu \
+    powerpc64le-unknown-linux-gnu\
+"
+
+
+##
+# rust-lang ressource
+##
+RUSTC_CHECKSUM_URI="https://static.rust-lang.org/dist/rustc-${RUST_VERSION}-src.tar.xz.sha256"
+STAGE0_URI="https://raw.githubusercontent.com/rust-lang/rust/${RUST_VERSION}/src/stage0"
+
+RUSTSTD_PREFIX="rust-std"
+RUSTC_PREFIX="rustc"
+CARGO_PREFIX="cargo"
+TARBALL_FORMAT="tar.xz"
+###
+
+get_checksum_for_snapshot_json () {
+    [ $# -lt 2 ] && return 10
+    _snapshot_version="${1}"
+    _arch="${2}"
+
+    _arch_only="$(echo "${_arch}" |cut -d'-' -f1)"
+
+    printf -- "Get sha256 for arch %s (snapshot version %s)\n" "${_arch}" "${_snapshot_version}"
+
+    # rust-std
+    printf -- "- Update recipes-devtool/rust-snapshot-%s.inc:\n\tSRC_URI[%s-snapshot-%s.sha256sum] = " \
+        "${RUST_VERSION}" \
+        "${RUSTSTD_PREFIX}" "${_arch_only}"
+    jq .checksums_sha256 <"${OUT}" | grep "$(printf -- "%s-%s-%s.%s" "${RUSTSTD_PREFIX}" "${_snapshot_version}" "${_arch}" "${TARBALL_FORMAT}")" |sed -n -r -e 's/\s+".*": "([a-f0-9]{1,64})",$/\1/p'
+    printf -- "\n"
+
+    # rustc
+    printf -- "- recipes-devtool/rust-snapshot-%s.inc:\n\tSRC_URI[%s-snapshot-%s.sha256sum] = " \
+        "${RUST_VERSION}" \
+        "${RUSTC_PREFIX}" "${_arch_only}"
+    jq .checksums_sha256 <"${OUT}" | grep "$(printf -- "%s-%s-%s.%s" "${RUSTC_PREFIX}" "${_snapshot_version}" "${_arch}" "${TARBALL_FORMAT}")" |sed -n -r -e 's/\s+".*": "([a-f0-9]{1,64})",$/\1/p'
+    printf -- "\n"
+
+    # cargo
+    printf -- "- recipes-devtool/rust-snapshot-%s.inc:\n\tSRC_URI[%s-snapshot-%s.sha256sum] = " \
+        "${RUST_VERSION}" \
+        "${CARGO_PREFIX}" "${_arch_only}"
+    jq .checksums_sha256 <"${OUT}" | grep "$(printf -- "%s-%s-%s.%s" "${CARGO_PREFIX}" "${_snapshot_version}" "${_arch}" "${TARBALL_FORMAT}")" |sed -n -r -e 's/\s+".*": "([a-f0-9]{1,64})",$/\1/p'
+    printf -- "\n"
+}
+
+get_checksum_for_snapshot () {
+    [ $# -lt 2 ] && return 10
+    _snapshot_version="${1}"
+    _arch="${2}"
+    _arch_only="$(echo "${_arch}" | cut -d'-' -f1 -)"
+
+    printf -- "Get sha256 for arch %s (snapshot version %s)\n" "${_arch}" "${_snapshot_version}"
+
+    # rust-std
+    printf -- "- Update recipes-devtool/rust-snapshot-%s.inc:\n\tSRC_URI[%s-snapshot-%s.sha256sum] = " \
+        "${RUST_VERSION}" \
+        "${RUSTSTD_PREFIX}" "${_arch_only}"
+    grep "$(printf -- "%s-%s-%s.%s" "${RUSTSTD_PREFIX}" "${_snapshot_version}" "${_arch}" "${TARBALL_FORMAT}")" "${OUT}" |cut -d'=' -f2
+    printf -- "\n"
+
+    # rustc
+    printf -- "- recipes-devtool/rust-snapshot-%s.inc:\n\tSRC_URI[%s-snapshot-%s.sha256sum] = " \
+        "${RUST_VERSION}" \
+        "${RUSTC_PREFIX}" "${_arch_only}"
+    grep "$(printf -- "%s-%s-%s.%s" "${RUSTC_PREFIX}" "${_snapshot_version}" "${_arch}" "${TARBALL_FORMAT}")" "${OUT}" |cut -d'=' -f2
+    printf -- "\n"
+
+    # cargo
+    printf -- "- recipes-devtool/rust-snapshot-%s.inc:\n\tSRC_URI[%s-snapshot-%s.sha256sum] = " \
+        "${RUST_VERSION}" \
+        "${CARGO_PREFIX}" "${_arch_only}"
+    grep "$(printf -- "%s-%s-%s.%s" "${CARGO_PREFIX}" "${_snapshot_version}" "${_arch}" "${TARBALL_FORMAT}")" "${OUT}" |cut -d'=' -f2
+    printf -- "\n"
+}
+
+##
+# WARNING
+##
+# To avoid getting rustc archive and compute sha256sum on it
+# we get directly the sha256sum file
+get_rustcsrc_sha256 () {
+    # Note: sha256sum length is 32bytes but can produce less than 64 hex character
+    curl "${RUSTC_CHECKSUM_URI}" 2>/dev/null | sed -n -r -e 's/([a-f0-9]{1,64}).*$/\1/p'
+}
 
 # Get Stage0
-curl -s -S --header "Accept: application/json" \
-    "https://raw.githubusercontent.com/rust-lang/rust/${RUST_VERSION}/src/stage0.json" \
-    -o "${OUT}"
+#   - ${1}: Output file path
+#   - [$2 : Get JSON (before rust 1.80.0)]
+get_stage0 () {
+    [ "$#" -lt 1 ] && return 10
 
-STAGE0_RUST_VERSION=$(jq -r .compiler.version <"${OUT}")
-printf -- "Compiler version for stage0 is : %s\n" "${STAGE0_RUST_VERSION}"
+    # Note: No local in posix shell, use _
+    _out="${1}"
+    _json="${2:-undef}"
 
-
-# x86_64-unknown-linux-gnu
-printf -- "Hashes (sha256sum) for x86_64-unknow-linux-gnu.tar.xz snapshot\n"
-
-printf -- "- rust-std-%s-x86_64-unknown-linux-gnu.tar.xz\n" "${STAGE0_RUST_VERSION}"
-jq .checksums_sha256 <"${OUT}" | grep "rust-std-${STAGE0_RUST_VERSION}-x86_64-unknown-linux-gnu.tar.xz"
-printf -- "\n"
-
-printf -- "- rustc-%s-x86_64-unknown-linux-gnu.tar.xz\n" "${STAGE0_RUST_VERSION}"
-jq .checksums_sha256 <"${OUT}" | grep "rustc-${STAGE0_RUST_VERSION}-x86_64-unknown-linux-gnu.tar.xz"
-printf -- "\n"
-
-printf -- "- cargo-%s-x86_64-unknown-linux-gnu.tar.xz\n" "${STAGE0_RUST_VERSION}"
-jq .checksums_sha256 <"${OUT}" | grep "cargo-${STAGE0_RUST_VERSION}-x86_64-unknown-linux-gnu.tar.xz"
-printf -- "\n"
-
-
-# aarch64-unknown-linux-gnu
-printf -- "Hashes (sha256sum) for aarch64-unknown-linux-gnu snapshot\n"
-
-printf -- "- rust-std-%s-aarch64-unknown-linux-gnu.tar.xz\n" "${STAGE0_RUST_VERSION}"
-jq .checksums_sha256 <"${OUT}" | grep "rust-std-${STAGE0_RUST_VERSION}-aarch64-unknown-linux-gnu.tar.xz"
-printf -- "\n"
-
-printf -- "- rustc-%s-aarch64-unknown-linux-gnu.tar.xz\n" "${STAGE0_RUST_VERSION}"
-jq .checksums_sha256 <"${OUT}" | grep "rustc-${STAGE0_RUST_VERSION}-aarch64-unknown-linux-gnu.tar.xz"
-printf -- "\n"
-
-printf -- "- cargo-%s-aarch64-unknown-linux-gnu.tar.xz\n" "${STAGE0_RUST_VERSION}"
-jq .checksums_sha256 <"${OUT}" | grep "cargo-${STAGE0_RUST_VERSION}-aarch64-unknown-linux-gnu.tar.xz"
-printf -- "\n"
-
-
-# powerpc64le-unknown-linux-gnu
-printf -- "Hashes (sha256sum) for powerpc64le snapshot\n"
-
-printf -- "- rust-std-%s-powerpc64le-unknown-linux-gnu.tar.xz\n" "${STAGE0_RUST_VERSION}"
-jq .checksums_sha256 <"${OUT}" | grep "rust-std-${STAGE0_RUST_VERSION}-powerpc64le-unknown-linux-gnu.tar.xz"
-printf -- "\n"
-printf -- "- rustc-%s-powerpc64le-unknown-linux-gnu.tar.xz\n" "${STAGE0_RUST_VERSION}"
-jq .checksums_sha256 <"${OUT}" | grep "rustc-${STAGE0_RUST_VERSION}-powerpc64le-unknown-linux-gnu.tar.xz"
-printf -- "\n"
-printf -- "- cargo-%s-powerpc64le-unknown-linux-gnu.tar.xz\n" "${STAGE0_RUST_VERSION}"
-jq .checksums_sha256 <"${OUT}" | grep "cargo-${STAGE0_RUST_VERSION}-powerpc64le-unknown-linux-gnu.tar.xz"
-printf -- "\n"
+    if [ "${_json}" = "undef" ]
+    then
+        # Get stage0
+        curl -s -S \
+	    "${STAGE0_URI}" \
+	    -o "${_out}"
+    else
+        # Get stage0.json
+        curl -s -S --header "Accept: application/json" \
+	    "${STAGE0_URI}.json" \
+	    -o "${_out}"
+    fi
+}
 
 
 
-printf -- "Do not forget to update hash for rust-source in 'recipes-devtools/rust/rust-source-%s.inc'\n" "${RUST_VERSION}"
+if [ "$(echo "${RUST_VERSION}"|cut -d'.' -f2 )" -ge 80 ]
+then # Plain text Stage0
+    OUT="$(mktemp --suffix=_stage0)"
 
+    get_stage0 "${OUT}"
+
+    STAGE0_RUST_VERSION=$(grep "compiler_version=" "${OUT}" | cut -d'=' -f2)
+    printf -- "Compiler version for stage0 is : %s\n" "${STAGE0_RUST_VERSION}"
+
+    # Get snapshot sha256sum
+    for arch in ${SUPPORTED_ARCH}
+    do
+        get_checksum_for_snapshot "${STAGE0_RUST_VERSION}" "${arch}"
+    done
+
+else # Json Stage0
+    OUT="$(mktemp --suffix=_stage0.json)"
+
+    ## Stage0 Json
+    printf -- "Get stage0.json for rust version %s\n" "${RUST_VERSION}"
+
+    get_stage0 "${OUT}" "json"
+    STAGE0_RUST_VERSION=$(jq -r .compiler.version <"${OUT}")
+    printf -- "Compiler version for stage0 is : %s\n" "${STAGE0_RUST_VERSION}"
+
+    # Get snapshot sha256sum
+    for arch in ${SUPPORTED_ARCH}
+    do
+        get_checksum_for_snapshot_json "${STAGE0_RUST_VERSION}" "${arch}"
+    done
+fi
+
+# Rustc Source
+printf -- "Create 'recipes-devtool/rust-source-%s.inc' with \`SRC_URI[rust.sha256sum] = %s\`\n" \
+    "${RUST_VERSION}" "$(get_rustcsrc_sha256)"
+
+# TODO: Check LLVM_RELEASE update
+printf -- "Check LLVM_RELEASE version for rust %s and update 'recipes-devtool/%s'\n" \
+    "${RUST_VERSION}" "rust-llvm_${RUST_VERSION}.bb"
 
 rm "${OUT}"


### PR DESCRIPTION
Update script/rust-get-stage0 for getting snapshot stage0 sha256sum from script.

Add rust 1.86.0

Warning: Update RUST_VERSION from 1.78.0 to 1.86.0.