### PR TITLE
crate-fetch: Allow network on do_compile when using local source

### DIFF
--- a/classes/crate-fetch.bbclass
+++ b/classes/crate-fetch.bbclass
@@ -13,4 +13,10 @@ python () {
         sys.path.insert(0, layerdir + "/lib")
         import crate
         bb.fetch2.methods.append( crate.Crate() )
+
+        # If we have local sources (e.g. devtool), we want to be able
+        # to fetch crates at do_compile task.
+        if d.getVar('EXTERNALSRC'):
+            d.setVarFlag('do_compile', 'network', '1')
+
 }


### PR DESCRIPTION
Allow do_compile to fetch crates on local workflow (e.g. devtool).

Fixes:
```
   failed to download from `https://index.crates.io/config.json`
   [6] Could not resolve hostname (Could not resolve host: index.crates.io)
```

Tested with:
```
meta-rust            = "master:bfe7f95179b9288d4157b4f09e8cf0e13624cf9f"           
meta-yocto-bsp       = "scarthgap:6f7e929ea6ea557f107c8ccffea69a7d73439591"
meta-oe              = "scarthgap:c29a18fa39ede952f3f6108ec007c1906e2d9a0d"
```
