### PR TITLE
rust 1.91.1 and some fixes

### DIFF
--- a/conf/distro/include/rust_versions.inc
+++ b/conf/distro/include/rust_versions.inc
@@ -1,7 +1,7 @@
 # include this in your distribution to easily switch between versions
 # just by changing RUST_VERSION variable
 
-RUST_VERSION ?= "1.90.0"
+RUST_VERSION ?= "1.91.1"
 
 PREFERRED_VERSION_cargo ?= "${RUST_VERSION}"
 PREFERRED_VERSION_cargo-cross-canadian-${TARGET_ARCH} ?= "${RUST_VERSION}"

--- a/recipes-devtools/cargo/cargo-cross-canadian_1.91.1.bb
+++ b/recipes-devtools/cargo/cargo-cross-canadian_1.91.1.bb
@@ -1,0 +1,6 @@
+require recipes-devtools/rust/rust-source-${PV}.inc
+require recipes-devtools/rust/rust-snapshot-${PV}.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/cargo-${PV}:"
+
+require cargo-cross-canadian.inc

--- a/recipes-devtools/cargo/cargo_1.91.1.bb
+++ b/recipes-devtools/cargo/cargo_1.91.1.bb
@@ -1,0 +1,4 @@
+require recipes-devtools/rust/rust-source-${PV}.inc
+require recipes-devtools/rust/rust-snapshot-${PV}.inc
+require cargo.inc
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/rust/libstd-rs_1.91.1.bb
+++ b/recipes-devtools/rust/libstd-rs_1.91.1.bb
@@ -1,0 +1,10 @@
+require rust-source-${PV}.inc
+require libstd-rs.inc
+
+LIC_FILES_CHKSUM = "file://../../COPYRIGHT;md5=11a3899825f4376896e438c8c753f8dc"
+
+# libstd moved from src/libstd to library/std in 1.47+
+S = "${RUSTSRC}/library/std"
+
+# ref: https://github.com/rust-lang/rust/issues/133857
+RUSTFLAGS += "-Zforce-unstable-if-unmarked"

--- a/recipes-devtools/rust/rust-common.inc
+++ b/recipes-devtools/rust/rust-common.inc
@@ -150,7 +150,7 @@ TARGET_C_INT_WIDTH[aarch64] = "32"
 MAX_ATOMIC_WIDTH[aarch64] = "128"
 
 ## x86_64-unknown-linux-{gnu, musl}
-DATA_LAYOUT[x86_64] = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+DATA_LAYOUT[x86_64] = "${@'e-m:e-i64:64-f80:128-n8:16:32:64-S128' if bb.utils.vercmp_string_op(d.getVar('PV', True), '1.75.0', '<=') else 'e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128'}"
 LLVM_TARGET[x86_64] = "${RUST_TARGET_SYS}"
 TARGET_ENDIAN[x86_64] = "little"
 TARGET_POINTER_WIDTH[x86_64] = "64"

--- a/recipes-devtools/rust/rust-common.inc
+++ b/recipes-devtools/rust/rust-common.inc
@@ -376,6 +376,8 @@ def rust_gen_target(d, thing, wd, features, cpu, arch, abi=""):
     tspec['linker-is-gnu'] = True
     tspec['linker-flavor'] = "gcc"
     tspec['has-rpath'] = True
+    if bb.utils.vercmp_string_op(d.getVar('PV', True), "1.86.0", "<="):
+       tspec['has-elf-tls'] = True
     tspec['position-independent-executables'] = True
     tspec['panic-strategy'] = d.getVar("RUST_PANIC_STRATEGY")
 

--- a/recipes-devtools/rust/rust-cross-canadian_1.91.1.bb
+++ b/recipes-devtools/rust/rust-cross-canadian_1.91.1.bb
@@ -1,0 +1,6 @@
+require rust-cross-canadian.inc
+require rust-source-${PV}.inc
+require rust-snapshot-${PV}.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/rust:"
+

--- a/recipes-devtools/rust/rust-cross_1.91.1.bb
+++ b/recipes-devtools/rust/rust-cross_1.91.1.bb
@@ -1,0 +1,6 @@
+require rust-cross.inc
+require rust-source-${PV}.inc
+
+# License file checksum needed for do_populate_lic when including a
+# Rust app in an image.
+LIC_FILES_CHKSUM="file://LICENSE-APACHE;md5=22a53954e4e0ec258dfce4391e905dac"

--- a/recipes-devtools/rust/rust-crosssdk_1.91.1.bb
+++ b/recipes-devtools/rust/rust-crosssdk_1.91.1.bb
@@ -1,0 +1,6 @@
+require rust-crosssdk.inc
+require rust-source-${PV}.inc
+
+# License file checksum needed for do_populate_lic when including a
+# Rust app in an image.
+LIC_FILES_CHKSUM="file://LICENSE-APACHE;md5=22a53954e4e0ec258dfce4391e905dac"

--- a/recipes-devtools/rust/rust-llvm_1.91.1.bb
+++ b/recipes-devtools/rust/rust-llvm_1.91.1.bb
@@ -1,0 +1,5 @@
+# check src/llvm-project/cmake/modules/LLVMVersion.cmake for llvm version in use
+#
+LLVM_RELEASE = "21.1.5"
+require rust-source-${PV}.inc
+require rust-llvm.inc

--- a/recipes-devtools/rust/rust-snapshot-1.91.1.inc
+++ b/recipes-devtools/rust/rust-snapshot-1.91.1.inc
@@ -1,0 +1,34 @@
+## This is information on the rust-snapshot (binary) used to build our current release.
+## snapshot info is taken from rust/src/stage0
+## Rust is self-hosting and bootstraps itself with a pre-built previous version of itself.
+## The exact (previous) version that has been used is specified in the source tarball.
+## The version is replicated here.
+## TODO: find a way to add additional SRC_URIs based on the contents of an
+##       earlier SRC_URI.
+
+SNAPSHOT_VERSION = "1.90.0"
+
+# TODO: Add hashes for other architecture toolchains as well.
+
+# You can use scripts/rust-get-stage0.sh to update hashes
+SRC_URI[rust-std-snapshot-x86_64.sha256sum] = "663f4ab7945b392d5e5294dec1b050a66820a20e86f084ec37eeb0f2f7ff5569"
+SRC_URI[rustc-snapshot-x86_64.sha256sum] = "48c2a42de9e92fcae8c24568f5fe40d5734696a6f80e83cc6d46eef1a78f13c9"
+SRC_URI[cargo-snapshot-x86_64.sha256sum] = "9853db03d68578a30972e2755c89c66aec035fec641cf8f3a7117c81eec2578d"
+
+SRC_URI[rust-std-snapshot-aarch64.sha256sum] = "4952abb7d9d3ed7cea4f7ea44dcb23dc67631fae4ac44a5f059b90a4b5e9223f"
+SRC_URI[rustc-snapshot-aarch64.sha256sum] = "4e1a9987a11d7d91f0d5afbf5333feb62f44172e4a31f33ce7246549003217f2"
+SRC_URI[cargo-snapshot-aarch64.sha256sum] = "bd8d1da6fe88ea7e29338f24277c22156267447adbfc47d690467ad32d02c2a7"
+
+SRC_URI[rust-std-snapshot-powerpc64le.sha256sum] = "eac29f92ccd335c51553c362c7a6d3de2eb7071b5ae3839470e351a6a3ebdb77"
+SRC_URI[rustc-snapshot-powerpc64le.sha256sum] = "e87b8eb926a65211a99f6712ff376c5950b4b11c67ed7f92019da27a34ae7085"
+SRC_URI[cargo-snapshot-powerpc64le.sha256sum] = "f029151dfeed6570b8b347e04a5bb7dcb9c59d8e5454c535c05bb5069c216354"
+
+SRC_URI += " \
+    https://static.rust-lang.org/dist/${RUST_STD_SNAPSHOT}.tar.xz;name=rust-std-snapshot-${RUST_BUILD_ARCH};subdir=rust-snapshot-components \
+    https://static.rust-lang.org/dist/${RUSTC_SNAPSHOT}.tar.xz;name=rustc-snapshot-${RUST_BUILD_ARCH};subdir=rust-snapshot-components \
+    https://static.rust-lang.org/dist/${CARGO_SNAPSHOT}.tar.xz;name=cargo-snapshot-${RUST_BUILD_ARCH};subdir=rust-snapshot-components \
+"
+
+RUST_STD_SNAPSHOT = "rust-std-${SNAPSHOT_VERSION}-${RUST_BUILD_ARCH}-unknown-linux-gnu"
+RUSTC_SNAPSHOT = "rustc-${SNAPSHOT_VERSION}-${RUST_BUILD_ARCH}-unknown-linux-gnu"
+CARGO_SNAPSHOT = "cargo-${SNAPSHOT_VERSION}-${RUST_BUILD_ARCH}-unknown-linux-gnu"

--- a/recipes-devtools/rust/rust-source-1.91.1.inc
+++ b/recipes-devtools/rust/rust-source-1.91.1.inc
@@ -1,0 +1,7 @@
+SRC_URI += "https://static.rust-lang.org/dist/rustc-${PV}-src.tar.xz;name=rust"
+SRC_URI[rust.sha256sum] = "66401bb815e236cc6b2aacbbe23b61b286c1fe27a67902e7c0222cfe77b3dbab"
+
+RUSTSRC = "${WORKDIR}/rustc-${PV}-src"
+
+UPSTREAM_CHECK_URI = "https://forge.rust-lang.org/infra/other-installation-methods.html"
+UPSTREAM_CHECK_REGEX = "rustc-(?P<pver>\d+(\.\d+)+)-src"

--- a/recipes-devtools/rust/rust-tools-cross-canadian_1.91.1.bb
+++ b/recipes-devtools/rust/rust-tools-cross-canadian_1.91.1.bb
@@ -1,0 +1,6 @@
+require rust-tools-cross-canadian.inc
+require rust-source-${PV}.inc
+require rust-snapshot-${PV}.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/rust:"
+

--- a/recipes-devtools/rust/rust_1.91.1.bb
+++ b/recipes-devtools/rust/rust_1.91.1.bb
@@ -1,0 +1,25 @@
+require rust-target.inc
+require rust-source-${PV}.inc
+require rust-snapshot-${PV}.inc
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=11a3899825f4376896e438c8c753f8dc"
+
+INSANE_SKIP:${PN}:class-native = "already-stripped"
+
+DEPENDS += "ninja-native"
+
+do_compile () {
+    rust_runx build --stage 2
+}
+
+rust_do_install() {
+    rust_runx install
+}
+
+python () {
+    pn = d.getVar('PN')
+
+    if not pn.endswith("-native"):
+        raise bb.parse.SkipRecipe("Rust recipe doesn't work for target builds at this time. Fixes welcome.")
+}
+


### PR DESCRIPTION
- Fix `$CARGO_HOME/cargo.toml` warning (and support older rust version by symlink it to `$CARGO_HOME/cargo`.
- Add rust version 1.91.1
- Update default rust version to 1.91.1
- Fix target spec Json generation
- Update conditionally DATA_LAYOUT with rust version for x86_64 (refs #450)

Tested on Yocto scarthgap version.


This PR is based on https://github.com/meta-rust/meta-rust/pull/474 waiting for integration.