### PR TITLE
cargo: sync upstream bbclass and crate fetcher improvements

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -27,9 +27,6 @@ export RUST_BACKTRACE = "1"
 # assume there's a Cargo.toml directly in the root directory
 CARGO_SRC_DIR ??= ""
 
-# The actual path to the Cargo.toml
-MANIFEST_PATH ??= "${S}/${CARGO_SRC_DIR}/Cargo.toml"
-
 # Features and additional flags for 'cargo build'.
 #
 # CARGO_FEATURES supports both, a comma or space separated list. Disabling
@@ -47,7 +44,7 @@ CARGO_BUILD_FLAGS = "\
     -v \
     --target ${RUST_HOST_SYS} \
     ${BUILD_MODE} \
-    --manifest-path=${MANIFEST_PATH} \
+    --manifest-path=${CARGO_MANIFEST_PATH} \
     ${@oe.utils.conditional('CARGO_NO_DEFAULT_FEATURES', '1', '--no-default-features', '', d)} \
     ${@oe.utils.conditional('CARGO_ALL_FEATURES', '1', '--all-features', '', d)} \
     ${@oe.utils.conditional('CARGO_FEATURES', '', '', '--features "${CARGO_FEATURES}"', d)} \

--- a/classes/cargo_common.bbclass
+++ b/classes/cargo_common.bbclass
@@ -172,3 +172,15 @@ oe_cargo_fix_env () {
 EXTRA_OECARGO_PATHS ??= ""
 
 EXPORT_FUNCTIONS do_configure
+
+# The culprit for this setting is the libc crate,
+# which as of Jun 2023 calls directly into 32 bit time functions in glibc,
+# bypassing all of glibc provisions to choose the right Y2038-safe functions. As
+# rust components statically link with that crate, pretty much everything
+# is affected, and so there's no point trying to have recipe-specific
+# INSANE_SKIP entries.
+#
+# Upstream ticket and PR:
+# https://github.com/rust-lang/libc/issues/3223
+# https://github.com/rust-lang/libc/pull/3175
+INSANE_SKIP:append = " 32bit-time"

--- a/classes/cargo_common.bbclass
+++ b/classes/cargo_common.bbclass
@@ -96,6 +96,10 @@ cargo_common_do_configure () {
 	# Put build output in build directory preferred by bitbake instead of
 	# inside source directory unless they are the same
 	if [ "${B}" != "${S}" ]; then
+		# We should consider mandating out-of-tree builds and just using [cleandirs]
+		rm -rf ${B}/target
+		mkdir -p ${B}
+
 		cat <<- EOF >> ${CARGO_HOME}/config.toml
 
 		[build]

--- a/classes/cargo_common.bbclass
+++ b/classes/cargo_common.bbclass
@@ -145,6 +145,9 @@ python cargo_common_do_patch_paths() {
                     repo = '%s://%s@%s%s' % (ud.proto, ud.user, ud.host, ud.path)
                 else:
                     repo = '%s://%s%s' % (ud.proto, ud.host, ud.path)
+                subdir = ud.parm.get('subdir')
+                if subdir is not None:
+                    destsuffix = os.path.join(destsuffix, subdir)
                 path = '%s = { path = "%s" }' % (name, os.path.join(workdir, destsuffix))
                 patches.setdefault(repo, []).append(path)
 

--- a/classes/cargo_common.bbclass
+++ b/classes/cargo_common.bbclass
@@ -157,7 +157,7 @@ python cargo_common_do_patch_paths() {
     # here is better than letting cargo tell (in case the file is missing)
     # "Cargo.lock should be modified but --frozen was given"
 
-    manifest_path = d.getVar("MANIFEST_PATH", True)
+    manifest_path = d.getVar("CARGO_MANIFEST_PATH", True)
     lockfile = os.path.join(os.path.dirname(manifest_path), "Cargo.lock")
     if not os.path.exists(lockfile):
         bb.fatal(f"{lockfile} file doesn't exist")

--- a/classes/cargo_common.bbclass
+++ b/classes/cargo_common.bbclass
@@ -133,7 +133,7 @@ python cargo_common_do_patch_paths() {
     fetcher = bb.fetch2.Fetch(src_uri, d)
     for url in fetcher.urls:
         ud = fetcher.ud[url]
-        if ud.type == 'git':
+        if ud.type == 'git' or ud.type == 'gitsm':
             name = ud.parm.get('name')
             destsuffix = ud.parm.get('destsuffix')
             if name is not None and destsuffix is not None:

--- a/classes/cargo_common.bbclass
+++ b/classes/cargo_common.bbclass
@@ -132,7 +132,10 @@ python cargo_common_do_patch_paths() {
             name = ud.parm.get('name')
             destsuffix = ud.parm.get('destsuffix')
             if name is not None and destsuffix is not None:
-                repo = '%s://%s%s' % (ud.proto, ud.host, ud.path)
+                if ud.user:
+                    repo = '%s://%s@%s%s' % (ud.proto, ud.user, ud.host, ud.path)
+                else:
+                    repo = '%s://%s%s' % (ud.proto, ud.host, ud.path)
                 path = '%s = { path = "%s" }' % (name, os.path.join(workdir, destsuffix))
                 patches.setdefault(repo, []).append(path)
 

--- a/classes/cargo_common.bbclass
+++ b/classes/cargo_common.bbclass
@@ -112,6 +112,38 @@ cargo_common_do_configure () {
 }
 cargo_common_do_configure[vardepsexclude] += "http_proxy"
 
+python cargo_common_do_patch_paths() {
+    import shutil
+
+    cargo_config = os.path.join(d.getVar("CARGO_HOME"), "config.toml")
+    if not os.path.exists(cargo_config):
+        return
+
+    src_uri = (d.getVar('SRC_URI') or "").split()
+    if len(src_uri) == 0:
+        return
+
+    patches = dict()
+    workdir = d.getVar('WORKDIR')
+    fetcher = bb.fetch2.Fetch(src_uri, d)
+    for url in fetcher.urls:
+        ud = fetcher.ud[url]
+        if ud.type == 'git':
+            name = ud.parm.get('name')
+            destsuffix = ud.parm.get('destsuffix')
+            if name is not None and destsuffix is not None:
+                repo = '%s://%s%s' % (ud.proto, ud.host, ud.path)
+                path = '%s = { path = "%s" }' % (name, os.path.join(workdir, destsuffix))
+                patches.setdefault(repo, []).append(path)
+
+    with open(cargo_config, "a+") as config:
+        for k, v in patches.items():
+            print('\n[patch."%s"]' % k, file=config)
+            for name in v:
+                print(name, file=config)
+}
+do_configure[postfuncs] += "cargo_common_do_patch_paths"
+
 oe_cargo_fix_env () {
 	export CC="${RUST_TARGET_CC}"
 	export CXX="${RUST_TARGET_CXX}"

--- a/classes/cargo_common.bbclass
+++ b/classes/cargo_common.bbclass
@@ -23,13 +23,15 @@ export PKG_CONFIG_ALLOW_CROSS = "1"
 # Don't instruct cargo to use crates downloaded by bitbake. Some rust packages,
 # for example the rust compiler itself, come with their own vendored sources.
 # Specifying two [source.crates-io] will not work.
-CARGO_DISABLE_BITBAKE_VENDORING ?= "0"
+CARGO_DISABLE_BITBAKE_VENDORING ??= "0"
 
 # Used by libstd-rs to point to the vendor dir included in rustc src
-CARGO_VENDORING_DIRECTORY ?= "${CARGO_HOME}/bitbake"
+CARGO_VENDORING_DIRECTORY ??= "${CARGO_HOME}/bitbake"
+
+# The actual path to the Cargo.toml
 CARGO_MANIFEST_PATH ??= "${S}/${CARGO_SRC_DIR}/Cargo.toml"
 
-CARGO_RUST_TARGET_CCLD ?= "${RUST_TARGET_CCLD}"
+CARGO_RUST_TARGET_CCLD ??= "${RUST_TARGET_CCLD}"
 cargo_common_do_configure () {
 	mkdir -p ${CARGO_HOME}/bitbake
 

--- a/classes/cargo_common.bbclass
+++ b/classes/cargo_common.bbclass
@@ -31,6 +31,9 @@ CARGO_VENDORING_DIRECTORY ??= "${CARGO_HOME}/bitbake"
 # The actual path to the Cargo.toml
 CARGO_MANIFEST_PATH ??= "${S}/${CARGO_SRC_DIR}/Cargo.toml"
 
+# Path to Cargo.lock
+CARGO_LOCK_PATH ??= "${@ os.path.join(os.path.dirname(d.getVar('CARGO_MANIFEST_PATH', True)), 'Cargo.lock')}"
+
 CARGO_RUST_TARGET_CCLD ??= "${RUST_TARGET_CCLD}"
 cargo_common_do_configure () {
 	mkdir -p ${CARGO_HOME}/bitbake
@@ -159,8 +162,7 @@ python cargo_common_do_patch_paths() {
     # here is better than letting cargo tell (in case the file is missing)
     # "Cargo.lock should be modified but --frozen was given"
 
-    manifest_path = d.getVar("CARGO_MANIFEST_PATH", True)
-    lockfile = os.path.join(os.path.dirname(manifest_path), "Cargo.lock")
+    lockfile = d.getVar("CARGO_LOCK_PATH", True)
     if not os.path.exists(lockfile):
         bb.fatal(f"{lockfile} file doesn't exist")
 

--- a/classes/cargo_common.bbclass
+++ b/classes/cargo_common.bbclass
@@ -147,6 +147,10 @@ python cargo_common_do_patch_paths() {
 }
 do_configure[postfuncs] += "cargo_common_do_patch_paths"
 
+do_compile:prepend () {
+        oe_cargo_fix_env
+}
+
 oe_cargo_fix_env () {
 	export CC="${RUST_TARGET_CC}"
 	export CXX="${RUST_TARGET_CXX}"

--- a/classes/cargo_common.bbclass
+++ b/classes/cargo_common.bbclass
@@ -144,6 +144,45 @@ python cargo_common_do_patch_paths() {
             print('\n[patch."%s"]' % k, file=config)
             for name in v:
                 print(name, file=config)
+
+    if not patches:
+        return
+
+    # Cargo.lock file is needed for to be sure that artifacts
+    # downloaded by the fetch steps are those expected by the
+    # project and that the possible patches are correctly applied.
+    # Moreover since we do not want any modification
+    # of this file (for reproducibility purpose), we prevent it by
+    # using --frozen flag (in CARGO_BUILD_FLAGS) and raise a clear error
+    # here is better than letting cargo tell (in case the file is missing)
+    # "Cargo.lock should be modified but --frozen was given"
+
+    manifest_path = d.getVar("MANIFEST_PATH", True)
+    lockfile = os.path.join(os.path.dirname(manifest_path), "Cargo.lock")
+    if not os.path.exists(lockfile):
+        bb.fatal(f"{lockfile} file doesn't exist")
+
+    # There are patched files and so Cargo.lock should be modified but we use
+    # --frozen so let's handle that modifications here.
+    #
+    # Note that a "better" (more elegant ?) would have been to use cargo update for
+    # patched packages:
+    #  cargo update --offline -p package_1 -p package_2
+    # But this is not possible since it requires that cargo local git db
+    # to be populated and this is not the case as we fetch git repo ourself.
+
+    lockfile_orig = lockfile + ".orig"
+    if not os.path.exists(lockfile_orig):
+        shutil.copy(lockfile, lockfile_orig)
+
+    newlines = []
+    with open(lockfile_orig, "r") as f:
+        for line in f.readlines():
+            if not line.startswith("source = \"git"):
+                newlines.append(line)
+
+    with open(lockfile, "w") as f:
+        f.writelines(newlines)
 }
 do_configure[postfuncs] += "cargo_common_do_patch_paths"
 

--- a/classes/cargo_common.bbclass
+++ b/classes/cargo_common.bbclass
@@ -52,7 +52,7 @@ cargo_common_do_configure () {
 
 		[source.crates-io]
 		replace-with = "bitbake"
-		local-registry = "/nonexistant"
+		local-registry = "/nonexistent"
 		EOF
 	fi
 
@@ -94,7 +94,7 @@ cargo_common_do_configure () {
 		cat <<- EOF >> ${CARGO_HOME}/config.toml
 
 		[build]
-		# Use out of tree build destination to avoid poluting the source tree
+		# Use out of tree build destination to avoid polluting the source tree
 		target-dir = "${B}/target"
 		EOF
 	fi

--- a/lib/crate.py
+++ b/lib/crate.py
@@ -83,7 +83,7 @@ class Crate(Wget):
         ud.url = "https://%s/%s/%s/download" % (host, name, version)
         ud.parm['downloadfilename'] = "%s-%s.crate" % (name, version)
         if 'name' not in ud.parm:
-            ud.parm['name'] = name
+            ud.parm['name'] = '%s-%s' % (name, version)
 
         logger.debug(2, "Fetching %s to %s" % (ud.url, ud.parm['downloadfilename']))
 

--- a/lib/crate.py
+++ b/lib/crate.py
@@ -25,6 +25,7 @@ import hashlib
 import json
 import os
 import subprocess
+from functools import cmp_to_key
 import bb
 from   bb.fetch2 import logger, subprocess_setup, UnpackError
 from   bb.fetch2.wget import Wget
@@ -169,7 +170,6 @@ class Crate(Wget):
         """
         Return the latest version available when versionsurl is the [name]/versions URL.
         """
-        from functools import cmp_to_key
         json_data = json.loads(self._fetch_index(ud.versionsurl, ud, d))
         versions = [(0, i["num"], "") for i in json_data["versions"]]
         versions = sorted(versions, key=cmp_to_key(bb.utils.vercmp))
@@ -182,8 +182,6 @@ class Crate(Wget):
         file.
         https://doc.rust-lang.org/cargo/reference/registry-index.html#index-files
         """
-        from functools import cmp_to_key
-
         versions = []
         response = self._fetch_index(ud.versionsurl, ud, d)
         for line in response.splitlines():

--- a/lib/crate.py
+++ b/lib/crate.py
@@ -56,6 +56,17 @@ class Crate(Wget):
 
         super(Crate, self).urldata_init(ud, d)
 
+    def _generate_index_path(self, name):
+        # https://doc.rust-lang.org/cargo/reference/registry-index.html#index-files
+        if len(name) == 1:
+            return f"1/{name}"
+        elif len(name) == 2:
+            return f"2/{name}"
+        elif len(name) == 3:
+            return f"3/{name[0]}/{name}"
+        else:
+            return f"{name[0:2]}/{name[2:4]}/{name}"
+
     def _crate_urldata_init(self, ud, d):
         """
         Sets up the download for a crate
@@ -76,15 +87,15 @@ class Crate(Wget):
         # host (this is to allow custom crate registries to be specified
         host = '/'.join(parts[2:-2])
 
-        # if using upstream just fix it up nicely
+        # If using crates.io use the CDN directly as per https://crates.io/data-access
         if host == 'crates.io':
-            host = 'crates.io/api/v1/crates'
-            cdn_host = 'static.crates.io/crates'
+            ud.url = "https://static.crates.io/crates/%s/%s/download" % (name, version)
+            ud.versionsurl = 'https://index.crates.io/' + self._generate_index_path(name)
+            self.latest_versionstring = self.latest_versionstring_from_index
         else:
-            cdn_host = host
+            ud.url = "https://%s/%s/%s/download" % (host, name, version)
+            ud.versionsurl = "https://%s/%s/versions" % (host, name)
 
-        ud.url = "https://%s/%s/%s/download" % (cdn_host, name, version)
-        ud.versionsurl = "https://%s/%s/versions" % (host, name)
         ud.parm['downloadfilename'] = "%s-%s.crate" % (name, version)
         if 'name' not in ud.parm:
             ud.parm['name'] = '%s-%s' % (name, version)
@@ -155,9 +166,29 @@ class Crate(Wget):
                 json.dump(metadata, f)
 
     def latest_versionstring(self, ud, d):
+        """
+        Return the latest version available when versionsurl is the [name]/versions URL.
+        """
         from functools import cmp_to_key
         json_data = json.loads(self._fetch_index(ud.versionsurl, ud, d))
         versions = [(0, i["num"], "") for i in json_data["versions"]]
         versions = sorted(versions, key=cmp_to_key(bb.utils.vercmp))
 
+        return (versions[-1][1], "")
+
+    def latest_versionstring_from_index(self, ud, d):
+        """
+        Return the latest version available when versionsurl is a Cargo index
+        file.
+        https://doc.rust-lang.org/cargo/reference/registry-index.html#index-files
+        """
+        from functools import cmp_to_key
+
+        versions = []
+        response = self._fetch_index(ud.versionsurl, ud, d)
+        for line in response.splitlines():
+            data = json.loads(line)
+            versions.append((0, data["vers"], ""))
+
+        versions = sorted(versions, key=cmp_to_key(bb.utils.vercmp))
         return (versions[-1][1], "")

--- a/lib/crate.py
+++ b/lib/crate.py
@@ -24,7 +24,6 @@ BitBake 'Fetch' implementation for crates.io
 import hashlib
 import json
 import os
-import shutil
 import subprocess
 import bb
 from   bb.fetch2 import logger, subprocess_setup, UnpackError

--- a/lib/crate.py
+++ b/lib/crate.py
@@ -25,6 +25,7 @@ import hashlib
 import json
 import os
 import subprocess
+import re
 from functools import cmp_to_key
 import bb
 from   bb.fetch2 import logger, subprocess_setup, UnpackError
@@ -165,26 +166,27 @@ class Crate(Wget):
             with open(mdpath, "w") as f:
                 json.dump(metadata, f)
 
-    def latest_versionstring(self, ud, d):
+    def latest_versionstring(self, ud, d, filter_regex=None):
         """
         Return the latest upstream version, dispatching to the appropriate
         parser based on the versionsurl format.
         """
         if ud.versionsurl.startswith('https://index.crates.io/'):
-            return self._latest_versionstring_from_index(ud, d)
-        return self._latest_versionstring_from_api(ud, d)
+            return self._latest_versionstring_from_index(ud, d, filter_regex)
+        return self._latest_versionstring_from_api(ud, d, filter_regex)
 
-    def _latest_versionstring_from_api(self, ud, d):
+    def _latest_versionstring_from_api(self, ud, d, filter_regex=None):
         """
         Parse the latest version from a [name]/versions JSON API response.
         """
         json_data = json.loads(self._fetch_index(ud.versionsurl, ud, d))
         versions = [(0, i["num"], "") for i in json_data["versions"]]
+        if filter_regex:
+            versions = [v for v in versions if re.match(filter_regex, v[1])]
         versions = sorted(versions, key=cmp_to_key(bb.utils.vercmp))
-
         return (versions[-1][1], "") if versions else ("", "")
 
-    def _latest_versionstring_from_index(self, ud, d):
+    def _latest_versionstring_from_index(self, ud, d, filter_regex=None):
         """
         Parse the latest version from a Cargo sparse index file (NDJSON).
         https://doc.rust-lang.org/cargo/reference/registry-index.html#index-files
@@ -195,6 +197,9 @@ class Crate(Wget):
             data = json.loads(line)
             if not data.get("yanked", False):
                 versions.append((0, data["vers"], ""))
+
+        if filter_regex:
+            versions = [v for v in versions if re.match(filter_regex, v[1])]
 
         versions = sorted(versions, key=cmp_to_key(bb.utils.vercmp))
         return (versions[-1][1], "") if versions else ("", "")

--- a/lib/crate.py
+++ b/lib/crate.py
@@ -109,8 +109,8 @@ class Crate(Wget):
         save_cwd = os.getcwd()
         os.chdir(rootdir)
 
-        pn = d.getVar('BPN')
-        if pn == ud.parm.get('name'):
+        bp = d.getVar('BP')
+        if bp == ud.parm.get('name'):
             cmd = "tar -xz --no-same-owner -f %s" % thefile
         else:
             cargo_bitbake = self._cargo_bitbake_path(rootdir)

--- a/lib/crate.py
+++ b/lib/crate.py
@@ -92,7 +92,6 @@ class Crate(Wget):
         if host == 'crates.io':
             ud.url = "https://static.crates.io/crates/%s/%s/download" % (name, version)
             ud.versionsurl = 'https://index.crates.io/' + self._generate_index_path(name)
-            self.latest_versionstring = self.latest_versionstring_from_index
         else:
             ud.url = "https://%s/%s/%s/download" % (host, name, version)
             ud.versionsurl = "https://%s/%s/versions" % (host, name)
@@ -168,7 +167,16 @@ class Crate(Wget):
 
     def latest_versionstring(self, ud, d):
         """
-        Return the latest version available when versionsurl is the [name]/versions URL.
+        Return the latest upstream version, dispatching to the appropriate
+        parser based on the versionsurl format.
+        """
+        if ud.versionsurl.startswith('https://index.crates.io/'):
+            return self._latest_versionstring_from_index(ud, d)
+        return self._latest_versionstring_from_api(ud, d)
+
+    def _latest_versionstring_from_api(self, ud, d):
+        """
+        Parse the latest version from a [name]/versions JSON API response.
         """
         json_data = json.loads(self._fetch_index(ud.versionsurl, ud, d))
         versions = [(0, i["num"], "") for i in json_data["versions"]]
@@ -176,10 +184,9 @@ class Crate(Wget):
 
         return (versions[-1][1], "") if versions else ("", "")
 
-    def latest_versionstring_from_index(self, ud, d):
+    def _latest_versionstring_from_index(self, ud, d):
         """
-        Return the latest version available when versionsurl is a Cargo index
-        file.
+        Parse the latest version from a Cargo sparse index file (NDJSON).
         https://doc.rust-lang.org/cargo/reference/registry-index.html#index-files
         """
         versions = []

--- a/lib/crate.py
+++ b/lib/crate.py
@@ -188,7 +188,8 @@ class Crate(Wget):
         response = self._fetch_index(ud.versionsurl, ud, d)
         for line in response.splitlines():
             data = json.loads(line)
-            versions.append((0, data["vers"], ""))
+            if not data.get("yanked", False):
+                versions.append((0, data["vers"], ""))
 
         versions = sorted(versions, key=cmp_to_key(bb.utils.vercmp))
         return (versions[-1][1], "")

--- a/lib/crate.py
+++ b/lib/crate.py
@@ -67,8 +67,10 @@ class Crate(Wget):
         if len(parts) < 5:
             raise bb.fetch2.ParameterError("Invalid URL: Must be crate://HOST/NAME/VERSION", ud.url)
 
-        # last field is version
-        version = parts[len(parts) - 1]
+        # version is expected to be the last token
+        # but ignore possible url parameters which will be used
+        # by the top fetcher class
+        version, _, _ = parts[len(parts) -1].partition(";")
         # second to last field is name
         name = parts[len(parts) - 2]
         # host (this is to allow custom crate registries to be specified
@@ -80,7 +82,8 @@ class Crate(Wget):
 
         ud.url = "https://%s/%s/%s/download" % (host, name, version)
         ud.parm['downloadfilename'] = "%s-%s.crate" % (name, version)
-        ud.parm['name'] = name
+        if 'name' not in ud.parm:
+            ud.parm['name'] = name
 
         logger.debug(2, "Fetching %s to %s" % (ud.url, ud.parm['downloadfilename']))
 

--- a/lib/crate.py
+++ b/lib/crate.py
@@ -174,7 +174,7 @@ class Crate(Wget):
         versions = [(0, i["num"], "") for i in json_data["versions"]]
         versions = sorted(versions, key=cmp_to_key(bb.utils.vercmp))
 
-        return (versions[-1][1], "")
+        return (versions[-1][1], "") if versions else ("", "")
 
     def latest_versionstring_from_index(self, ud, d):
         """
@@ -192,4 +192,4 @@ class Crate(Wget):
                 versions.append((0, data["vers"], ""))
 
         versions = sorted(versions, key=cmp_to_key(bb.utils.vercmp))
-        return (versions[-1][1], "")
+        return (versions[-1][1], "") if versions else ("", "")

--- a/lib/crate.py
+++ b/lib/crate.py
@@ -79,8 +79,11 @@ class Crate(Wget):
         # if using upstream just fix it up nicely
         if host == 'crates.io':
             host = 'crates.io/api/v1/crates'
+            cdn_host = 'static.crates.io/crates'
+        else:
+            cdn_host = host
 
-        ud.url = "https://%s/%s/%s/download" % (host, name, version)
+        ud.url = "https://%s/%s/%s/download" % (cdn_host, name, version)
         ud.versionsurl = "https://%s/%s/versions" % (host, name)
         ud.parm['downloadfilename'] = "%s-%s.crate" % (name, version)
         if 'name' not in ud.parm:

--- a/lib/crate.py
+++ b/lib/crate.py
@@ -70,11 +70,11 @@ class Crate(Wget):
         # version is expected to be the last token
         # but ignore possible url parameters which will be used
         # by the top fetcher class
-        version, _, _ = parts[len(parts) -1].partition(";")
+        version = parts[-1].split(";")[0]
         # second to last field is name
-        name = parts[len(parts) - 2]
+        name = parts[-2]
         # host (this is to allow custom crate registries to be specified
-        host = '/'.join(parts[2:len(parts) - 2])
+        host = '/'.join(parts[2:-2])
 
         # if using upstream just fix it up nicely
         if host == 'crates.io':

--- a/lib/crate.py
+++ b/lib/crate.py
@@ -81,6 +81,7 @@ class Crate(Wget):
             host = 'crates.io/api/v1/crates'
 
         ud.url = "https://%s/%s/%s/download" % (host, name, version)
+        ud.versionsurl = "https://%s/%s/versions" % (host, name)
         ud.parm['downloadfilename'] = "%s-%s.crate" % (name, version)
         if 'name' not in ud.parm:
             ud.parm['name'] = '%s-%s' % (name, version)
@@ -149,3 +150,11 @@ class Crate(Wget):
             mdpath = os.path.join(bbpath, cratepath, mdfile)
             with open(mdpath, "w") as f:
                 json.dump(metadata, f)
+
+    def latest_versionstring(self, ud, d):
+        from functools import cmp_to_key
+        json_data = json.loads(self._fetch_index(ud.versionsurl, ud, d))
+        versions = [(0, i["num"], "") for i in json_data["versions"]]
+        versions = sorted(versions, key=cmp_to_key(bb.utils.vercmp))
+
+        return (versions[-1][1], "")


### PR DESCRIPTION
Backport the bulk of upstream cargo-related improvements from
openembedded-core.

crate fetcher (lib/crate.py):

- Switch fetching and version checking to crates.io CDN endpoints
  (static.crates.io, index.crates.io) per the official data access
  policy, replacing the slower v1 API
- Add sparse index (NDJSON) parsing for latest_versionstring, with
  filter_regex support for filtering candidate versions
- Skip yanked versions when reading the cargo index
- Guard against empty version lists
- Create versioned name parm entries (name-version) so multiple
  crates from the same recipe don't collide
- Fix incorrect unpack path for a crate whose name matches the
  recipe: compare against BP (includes version) rather than BPN
- Replace instance-method monkey-patching with URL-based dispatch;
  move cmp_to_key import to module level; drop unused import

git dependency support (classes/cargo_common.bbclass):

- Add cargo_common_do_patch_paths post-configure function that
  rewrites config.toml with [patch] sections for any git/gitsm
  SRC_URI entries carrying a name and destsuffix, pointing cargo at
  the already-fetched local paths
- Support subdir parameter on git URIs so cargo can find a crate in
  a subdirectory of a cloned repo
- Support authenticated git URLs (user@ prefix) in patch entries
- Handle Cargo.lock modifications required when patches are active:
  strip "source = git..." lines so --frozen builds don't fail
- Add CARGO_LOCK_PATH variable (defaults to Cargo.lock alongside
  CARGO_MANIFEST_PATH) with a clear bb.fatal if the lockfile is
  missing when patches are present
- Ensure ${B}/target is clean before configure when building
  out-of-tree

Cleanup and housekeeping:

- Rename MANIFEST_PATH -> CARGO_MANIFEST_PATH (definition moved to
  cargo_common; cargo.bbclass updated to match)
- Convert CARGO_DISABLE_BITBAKE_VENDORING, CARGO_VENDORING_DIRECTORY
  and CARGO_RUST_TARGET_CCLD to weak defaults (??=)
- Add do_compile:prepend to ensure oe_cargo_fix_env is always called
- Fix typos (nonexistant -> nonexistent, poluting -> polluting)
- Append 32bit-time to INSANE_SKIP globally in cargo_common to
  suppress the false-positive QA warning caused by the libc crate
  bypassing glibc's Y2038 shims (upstream: rust-lang/libc#3223)